### PR TITLE
Match updated filename for removing 99-fake_cloud.cfg

### DIFF
--- a/devices/cm3/cm3.py
+++ b/devices/cm3/cm3.py
@@ -247,7 +247,7 @@ class CM3:
                     # cloud-init won't find the user-data we give it
                     rm_cmd = "sudo rm -f {}".format(
                         os.path.join(
-                            base, "etc/cloud/cloud.cfg.d/99-fake_cloud.cfg"
+                            base, "etc/cloud/cloud.cfg.d/99-fake?cloud.cfg"
                         )
                     )
                     self._run_control(rm_cmd)

--- a/devices/muxpi/muxpi.py
+++ b/devices/muxpi/muxpi.py
@@ -389,7 +389,7 @@ class MuxPi:
                     # cloud-init won't find the user-data we give it
                     rm_cmd = "sudo rm -f {}".format(
                         os.path.join(
-                            base, "etc/cloud/cloud.cfg.d/99-fake_cloud.cfg"
+                            base, "etc/cloud/cloud.cfg.d/99-fake?cloud.cfg"
                         )
                     )
                     self._run_control(rm_cmd)

--- a/devices/rpi3/rpi3.py
+++ b/devices/rpi3/rpi3.py
@@ -401,7 +401,7 @@ class Rpi3:
                     # cloud-init won't find the user-data we give it
                     rm_cmd = "sudo rm -f {}".format(
                         os.path.join(
-                            base, "etc/cloud/cloud.cfg.d/99-fake_cloud.cfg"
+                            base, "etc/cloud/cloud.cfg.d/99-fake?cloud.cfg"
                         )
                     )
                     self._run_control(rm_cmd)


### PR DESCRIPTION
I've tested this with one of the rpi devices. It seems they changed the name of this file in kinetic to use a - instead of _ in the filename. We still need to remove it or else it will interfere with our cloud-init data that gets injected.