### PR TITLE
Fix post hard-reset connectivity check

### DIFF
--- a/devices/noprovision/noprovision.py
+++ b/devices/noprovision/noprovision.py
@@ -95,7 +95,7 @@ class Noprovision:
                     "/bin/true",
                 ]
                 subprocess.check_call(cmd)
-                break
+                return
             except subprocess.SubprocessError:
                 # keep going if we aren't booted yet
                 pass


### PR DESCRIPTION
If we break out of the while loop when the DUT is accessible after the hard-reset,
it will run the raise() in the end and the reservation will fail.

We should use return instead.