### PR TITLE
Improve handling of maas errors and a few more pylint cleanups

### DIFF
--- a/devices/maas2/__init__.py
+++ b/devices/maas2/__init__.py
@@ -15,18 +15,18 @@
 """Ubuntu MaaS 2.x CLI support code."""
 
 import logging
-import yaml
 
 import snappy_device_agents
+import yaml
+from devices import (
+    DefaultDevice,
+    ProvisioningError,
+    RecoveryError,
+    SerialLogger,
+    catch,
+)
 from devices.maas2.maas2 import Maas2
 from snappy_device_agents import logmsg
-from devices import (
-    catch,
-    DefaultDevice,
-    RecoveryError,
-    ProvisioningError,
-    SerialLogger,
-)
 
 device_name = "maas2"
 

--- a/devices/maas2/maas2.py
+++ b/devices/maas2/maas2.py
@@ -258,10 +258,8 @@ class Maas2:
         proc = subprocess.run(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
         )
-        try:
-            proc.check_returncode()
-        except subprocess.CalledProcessError:
-            self._logger_error("maas-cli call failure happens.")
+        if proc.returncode:
+            self._logger_error(f"maas-cli error running: {' '.join(cmd)}")
             raise ProvisioningError(proc.stdout.decode())
 
         # Make sure the device is available before returning

--- a/devices/maas2/maas2.py
+++ b/devices/maas2/maas2.py
@@ -19,9 +19,9 @@ import json
 import logging
 import subprocess
 import time
-import yaml
-
 from collections import OrderedDict
+
+import yaml
 from devices import ProvisioningError, RecoveryError
 
 logger = logging.getLogger()
@@ -83,7 +83,9 @@ class Maas2:
             "ubuntu@{}".format(self.config["device_ip"]),
             "sudo snap install efi-tools-ijohnson --devmode --edge",
         ]
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+        )
         cmd = [
             "ssh",
             "-o",
@@ -93,7 +95,9 @@ class Maas2:
             "ubuntu@{}".format(self.config["device_ip"]),
             "sudo snap alias efi-tools-ijohnson.efibootmgr efibootmgr",
         ]
-        subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+        )
 
     def _get_efi_data(self):
         cmd = [
@@ -106,7 +110,7 @@ class Maas2:
             "sudo efibootmgr -v",
         ]
         p = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
         )
         # If it fails the first time, try installing efitools snap
         if p.returncode:
@@ -121,7 +125,10 @@ class Maas2:
                 "sudo efibootmgr -v",
             ]
             p = subprocess.run(
-                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                check=False,
             )
         if p.returncode:
             return None
@@ -146,7 +153,7 @@ class Maas2:
             "sudo efibootmgr -o {}".format(boot_order),
         ]
         p = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
         )
         if p.returncode:
             self._logger_error(
@@ -191,24 +198,26 @@ class Maas2:
             "ubuntu@{}".format(self.config["device_ip"]),
             "echo 5 | sudo tee /sys/class/tpm/tpm0/ppi/request",
         ]
-        try:
-            subprocess.check_call(cmd, timeout=30)
-            cmd = [
-                "ssh",
-                "-o",
-                "StrictHostKeyChecking=no",
-                "-o",
-                "UserKnownHostsFile=/dev/null",
-                "ubuntu@{}".format(self.config["device_ip"]),
-                "cat /sys/class/tpm/tpm0/ppi/request",
-            ]
-            output = subprocess.check_output(cmd, timeout=30)
-            # If we now see "5" in that file, then clearing tpm succeeded
-            if output.decode("utf-8").strip() == "5":
-                return True
-        except Exception:
-            # Fall through if we fail for any reason
-            pass
+        proc = subprocess.run(cmd, timeout=30, check=False)
+        if proc.returncode:
+            return False
+
+        cmd = [
+            "ssh",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "ubuntu@{}".format(self.config["device_ip"]),
+            "cat /sys/class/tpm/tpm0/ppi/request",
+        ]
+        proc = subprocess.run(cmd, timeout=30, check=False)
+        if proc.returncode:
+            return False
+
+        # If we now see "5" in that file, then clearing tpm succeeded
+        if proc.stdout.decode("utf-8").strip() == "5":
+            return True
         return False
 
     def deploy_node(self, distro="bionic", kernel=None, user_data=None):
@@ -223,7 +232,12 @@ class Maas2:
             "system_id={}".format(self.node_id),
         ]
         # Do not use runcmd for this - we need the output, not the end user
-        subprocess.check_call(cmd)
+        proc = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+        )
+        if proc.returncode:
+            self._logger_error(f"maas error running: {' '.join(cmd)}")
+            raise ProvisioningError(proc.stdout.decode())
         self._logger_info(
             "Starting node {} "
             "with distro {}".format(self.agent_name, distro)
@@ -241,14 +255,14 @@ class Maas2:
         if user_data:
             data = base64.b64encode(user_data.encode()).decode()
             cmd.append("user_data={}".format(data))
-        process = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        proc = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
         )
         try:
-            process.check_returncode()
+            proc.check_returncode()
         except subprocess.CalledProcessError:
             self._logger_error("maas-cli call failure happens.")
-            raise ProvisioningError(process.stdout.decode())
+            raise ProvisioningError(proc.stdout.decode())
 
         # Make sure the device is available before returning
         minutes_spent = 0
@@ -281,7 +295,7 @@ class Maas2:
             'Device {} still in "{}" state, deployment '
             "failed!".format(self.agent_name, status)
         )
-        self._logger_error(process.stdout.decode())
+        self._logger_error(proc.stdout.decode())
         exception_msg = (
             "Provisioning failed because deployment timeout. "
             + "Deploying for more than "
@@ -301,8 +315,8 @@ class Maas2:
             "/bin/true",
         ]
         try:
-            subprocess.check_output(cmd, stderr=subprocess.STDOUT, timeout=60)
-        except Exception:
+            subprocess.check_call(cmd, stderr=subprocess.STDOUT, timeout=60)
+        except subprocess.SubprocessError:
             return False
         # If we get here, then the above command proved we are booted
         return True
@@ -317,16 +331,21 @@ class Maas2:
         """
         cmd = ["maas", self.maas_user, "machine", "read", self.node_id]
         # Do not use runcmd for this - we need the output, not the end user
-        output = subprocess.check_output(cmd)
-        data = json.loads(output.decode())
+        proc = subprocess.run(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
+        )
+        if proc.returncode:
+            self._logger_error(f"maas error running: {' '.join(cmd)}")
+            raise ProvisioningError(proc.stdout.decode())
+        data = json.loads(proc.stdout.decode())
         return data.get("status_name")
 
     def node_release(self):
         """Release the node to make it available again"""
         cmd = ["maas", self.maas_user, "machine", "release", self.node_id]
-        subprocess.run(cmd)
+        subprocess.run(cmd, check=False)
         # Make sure the device is available before returning
-        for timeout in range(0, 10):
+        for _ in range(0, 10):
             time.sleep(5)
             status = self.node_status()
             if status == "Ready":

--- a/devices/maas2/maas2.py
+++ b/devices/maas2/maas2.py
@@ -256,7 +256,7 @@ class Maas2:
             data = base64.b64encode(user_data.encode()).decode()
             cmd.append("user_data={}".format(data))
         proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=False
         )
         try:
             proc.check_returncode()
@@ -315,7 +315,9 @@ class Maas2:
             "/bin/true",
         ]
         try:
-            subprocess.check_call(cmd, stderr=subprocess.STDOUT, timeout=60)
+            subprocess.run(
+                cmd, stderr=subprocess.STDOUT, timeout=60, check=True
+            )
         except subprocess.SubprocessError:
             return False
         # If we get here, then the above command proved we are booted


### PR DESCRIPTION
fixes #26 
I tested this locally in a multipass container by misconfiguring the maas_id in the config file so that it didn't match, forcing the error.  It's still going to get an error, but it should be much nicer to read now.

This also includes a few more pylint cleanups that were somewhat related, and kept things more consistent.