### PR TITLE
Fix changes requested by new version of black formatting

### DIFF
--- a/snappy_device_agents/__init__.py
+++ b/snappy_device_agents/__init__.py
@@ -455,7 +455,7 @@ def _process_cmds_template_vars(cmds, config=None):
 
         def vformat(self, format_string, args, kwargs):
             tokens = []
-            for (literal, field_name, spec, conv) in self.parse(format_string):
+            for literal, field_name, spec, conv in self.parse(format_string):
                 # replace double braces if parse removed them
                 literal = literal.replace("{", "{{").replace("}", "}}")
                 # if the field is {}, just add escaped empty braces

--- a/snappy_device_agents/cmd.py
+++ b/snappy_device_agents/cmd.py
@@ -32,12 +32,12 @@ def main():
 
     # First add a subcommand for each supported device type
     dev_parser = parser.add_subparsers()
-    for (dev_name, dev_class) in devices:
+    for dev_name, dev_class in devices:
         dev_subparser = dev_parser.add_parser(dev_name)
         dev_module = dev_class()
         # Next add the subcommands that can be used and the methods they run
         cmd_subparser = dev_subparser.add_subparsers()
-        for (cmd, func) in (
+        for cmd, func in (
             ("provision", dev_module.provision),
             ("runtest", dev_module.runtest),
             ("reserve", dev_module.reserve),


### PR DESCRIPTION
Quick fix for something that's not really broken. Tox is installing the latest version of black, which makes new recommendations for formatting. This is to unblock other things from landing