### PR TITLE
Add a starting place for the multi-device agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ readme = "README.rst"
 requires-python = ">=3.8"
 dependencies = [
     "PyYAML>=3.11",
+    "requests",
 ]
 
 [project.scripts]

--- a/src/snappy_device_agents/devices/multi/__init__.py
+++ b/src/snappy_device_agents/devices/multi/__init__.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2023 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Ubuntu multi-device support code."""
+
+import json
+import logging
+import yaml
+
+import snappy_device_agents
+from snappy_device_agents import logmsg
+from snappy_device_agents.devices import (
+    DefaultDevice,
+)
+from snappy_device_agents.devices.multi.multi import Multi
+from snappy_device_agents.devices.multi.tfclient import TFClient
+
+device_name = "multi"
+
+
+class DeviceAgent(DefaultDevice):
+
+    """Device Agent for provisioning multiple devices at the same time"""
+
+    def provision(self, args):
+        """Method called when the command is invoked."""
+        with open(args.config, encoding="utf-8") as configfile:
+            config = yaml.safe_load(configfile)
+        with open(args.job_data, encoding="utf-8") as jobfile:
+            job_data = json.load(jobfile)
+        snappy_device_agents.configure_logging(config)
+        testflinger_server = config.get("testflinger_server")
+        tfclient = TFClient(testflinger_server)
+        device = Multi(config, job_data, tfclient)
+        logmsg(logging.INFO, "BEGIN provision")
+        logmsg(logging.INFO, "Provisioning device")
+        device.provision()
+        logmsg(logging.INFO, "END provision")

--- a/src/snappy_device_agents/devices/multi/multi.py
+++ b/src/snappy_device_agents/devices/multi/multi.py
@@ -1,0 +1,96 @@
+# Copyright (C) 2023 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Ubuntu multi-device support code."""
+
+import logging
+import os
+import time
+
+from snappy_device_agents.devices import ProvisioningError
+
+logger = logging.getLogger()
+
+
+class Multi:
+
+    """Device Agent for multi-device"""
+
+    def __init__(self, config, job_data, client):
+        """Initialize the multi-device agent.
+
+        :param config: path to the config file
+        :param job_data: path to the job data file
+        :param client: client object for talking to the Testflinger server
+        """
+        self.config = config
+        self.job_data = job_data
+        self.agent_name = self.config.get("agent_name")
+        self.mount_point = os.path.join("/mnt", self.agent_name)
+        self.client = client
+        self.jobs = []
+
+    def provision(self):
+        """Provision the multi-device agent by creating the specified jobs"""
+        self.create_jobs()
+
+        # Wait for all jobs to reach the "allocated" state
+        unallocated = self.jobs.copy()
+
+        while unallocated:
+            time.sleep(10)
+            for job in unallocated:
+                state = self.client.get_status(job)
+                if state == "allocated":
+                    unallocated.remove(job)
+                    break
+                if state in ("cancelled", "complete"):
+                    logger.error(
+                        "Job %s failed to allocate, cancelling remaining jobs",
+                        job,
+                    )
+                    self.cancel_jobs()
+                    raise ProvisioningError("Unable to allocate all jobs")
+
+    def create_jobs(self):
+        """Create the jobs for the multi-device agent"""
+        jobs_list = self.job_data.get("provision_data", {}).get("jobs")
+        if not jobs_list:
+            raise ProvisioningError(
+                "You must specify a list of 'jobs' in "
+                "the 'provision_data' section of "
+                "your job."
+            )
+
+        logger.info("Creating test jobs")
+        for job in jobs_list:
+            try:
+                job_id = self.client.submit_job(job)
+            except OSError as exc:
+                logger.exception("Unable to create job: %s", job_id)
+                self.cancel_jobs()
+                raise ProvisioningError(
+                    f"Unable to create job: {job_id}"
+                ) from exc
+
+            logger.info("Created job %s", job_id)
+            self.jobs.append(job_id)
+
+    def cancel_jobs(self):
+        """Try to cancel any jobs that were created"""
+        for job in self.jobs:
+            try:
+                self.client.cancel_job(job)
+            except OSError:
+                logger.exception("Unable to cancel job: %s", job)

--- a/src/snappy_device_agents/devices/multi/tfclient.py
+++ b/src/snappy_device_agents/devices/multi/tfclient.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2023 Canonical
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Client for talking to Testflinger Server"""
+
+import json
+import logging
+import urllib.parse
+import requests
+
+logger = logging.getLogger()
+
+
+class TFClient:
+    """Testflinger connection class"""
+
+    def __init__(self, url):
+        """Initialize the client with the url of the server
+
+        :param url: URL of the Testflinger server
+        """
+        self.server = url
+
+    def get(self, uri_frag, timeout=15):
+        """Submit a GET request to the server
+        :param uri_frag:
+            endpoint for the GET request
+        :return:
+            String containing the response from the server
+        """
+        uri = urllib.parse.urljoin(self.server, uri_frag)
+        try:
+            req = requests.get(uri, timeout=timeout)
+        except requests.exceptions.ConnectionError:
+            logger.error("Unable to communicate with specified server.")
+            raise
+        except IOError:
+            # This should catch all other timeout cases
+            logger.error(
+                "Timeout while trying to communicate with the server."
+            )
+            raise
+
+        try:
+            # If anything else went wrong, raise the proper exception
+            req.raise_for_status()
+        except OSError:
+            logger.error(
+                "Received status code %s from server.", req.status_code
+            )
+            raise
+        return req.text
+
+    def post(self, uri_frag, data, timeout=15):
+        """Submit a POST request to the server
+        :param uri_frag:
+            endpoint for the POST request
+        :return:
+            String containing the response from the server
+        """
+        uri = urllib.parse.urljoin(self.server, uri_frag)
+        try:
+            req = requests.post(uri, json=data, timeout=timeout)
+        except requests.exceptions.ConnectTimeout:
+            logger.error("Timout while trying to communicate with the server.")
+            raise
+        except requests.exceptions.ConnectionError:
+            logger.error("Unable to communicate with specified server.")
+            raise
+
+        try:
+            # If anything else went wrong, raise the proper exception
+            req.raise_for_status()
+        except OSError:
+            logger.error(
+                "Received status code %s from server.", req.status_code
+            )
+            raise
+        return req.text
+
+    def get_status(self, job_id):
+        """Get the status of a test job
+
+        :param job_id:
+            ID for the test job
+        :return:
+            String containing the job_state for the specified ID
+            (waiting, setup, provision, test, reserved, released,
+            cancelled, complete)
+        """
+        try:
+            endpoint = f"/v1/result/{job_id}"
+            data = json.loads(self.get(endpoint))
+            state = data.get("job_state")
+        except OSError:
+            logger.exception("Unable to get status for job %s", job_id)
+            state = "unknown"
+        return state
+
+    def submit_job(self, job_data):
+        """Submit a test job to the testflinger server
+
+        :param job_data:
+            dict of data for the job to submit
+        :return:
+            ID for the test job
+        """
+        endpoint = "/v1/job"
+        response = self.post(endpoint, job_data)
+        return json.loads(response).get("job_id")
+
+    def cancel_job(self, job_id):
+        """Tell the server to cancel a specified JOB_ID"""
+        try:
+            self.post(f"/v1/job/{job_id}/action", {"action": "cancel"})
+        except OSError:
+            logger.error("Unable to cancel job %s", job_id)
+            raise


### PR DESCRIPTION
This is just a starting place. It's not really functional yet, but does quite a bit already. It will submit jobs passed to it in the provision_data section, wait for them to reach the "allocated" state (which doesn't exist yet), and handle cancellation if something goes wrong.