### PR TITLE
create the remote tmpdir for limerick in case it's missing

### DIFF
--- a/src/snappy_device_agents/devices/muxpi/muxpi.py
+++ b/src/snappy_device_agents/devices/muxpi/muxpi.py
@@ -319,6 +319,7 @@ class MuxPi:
         try:
             data_path = Path(__file__).parent / "../../data"
             if image_type == "limerick":
+                self._run_control("mkdir -p {}".format(remote_tmp))
                 self._copy_to_control(
                     data_path / "limerick/user-data", remote_tmp
                 )


### PR DESCRIPTION
tiny fixup needed for limerick to create a tmpdir on the muxpi in case it's missing. This is just used for moving things like cloud-init userdata to the system before copying it into the right location and booting it.