### PR TITLE
Change default logging level back to info

### DIFF
--- a/src/snappy_device_agents/__init__.py
+++ b/src/snappy_device_agents/__init__.py
@@ -277,9 +277,10 @@ def configure_logging(config):
             return True
 
     logging.basicConfig(
+        level=logging.INFO,
         format="%(asctime)s %(agent_name)s %(levelname)s: "
         "DEVICE AGENT: "
-        "%(message)s"
+        "%(message)s",
     )
     agent_name = config.get("agent_name", "")
     logger.addFilter(AgentFilter(agent_name))


### PR DESCRIPTION
This used to be set in the snappy-device-agents script, but since we got rid of that, we need to set that default loglevel here, or else some messages might be missed