### PR TITLE
Inject the parent job_id into subordinate jobs for multi-device

### DIFF
--- a/src/snappy_device_agents/devices/multi/multi.py
+++ b/src/snappy_device_agents/devices/multi/multi.py
@@ -57,10 +57,8 @@ class Multi:
 
         while unallocated:
             time.sleep(10)
+            self.terminate_if_parent_complete()
             for job in unallocated:
-                if self.this_job_complete():
-                    self.cancel_jobs(self.jobs)
-                    raise ProvisioningError("Job cancelled or completed")
                 state = self.client.get_status(job)
                 if state == "allocated":
                     unallocated.remove(job)
@@ -80,6 +78,12 @@ class Multi:
                 )
 
         self.save_job_list_file()
+
+    def terminate_if_parent_complete(self):
+        """If parent job is complete or cancelled, cancel sub jobs"""
+        if self.this_job_complete():
+            self.cancel_jobs(self.jobs)
+            raise ProvisioningError("Job cancelled or completed")
 
     def this_job_complete(self):
         """

--- a/src/snappy_device_agents/devices/multi/multi.py
+++ b/src/snappy_device_agents/devices/multi/multi.py
@@ -122,6 +122,8 @@ class Multi:
                 logger.error("Job is not a dict: %s", job)
                 continue
             job = self.inject_allocate_data(job)
+            job = self.inject_parent_jobid(job)
+
             try:
                 job_id = self.client.submit_job(job)
             except OSError as exc:
@@ -142,6 +144,16 @@ class Multi:
         """
         allocate_data = {"allocate_data": {"allocate": True}}
         job.update(allocate_data)
+        return job
+
+    def inject_parent_jobid(self, job):
+        """Inject the parent job_id into the job
+
+        :param job: the job to inject the parent job_id into
+        :returns: the job with parent_job_id added to it
+        """
+        parent_job_id = {"parent_job_id": self.job_data.get("job_id")}
+        job.update(parent_job_id)
         return job
 
     def cancel_jobs(self, jobs):

--- a/src/snappy_device_agents/devices/multi/multi.py
+++ b/src/snappy_device_agents/devices/multi/multi.py
@@ -58,6 +58,9 @@ class Multi:
         while unallocated:
             time.sleep(10)
             for job in unallocated:
+                if self.this_job_complete():
+                    self.cancel_jobs(self.jobs)
+                    raise ProvisioningError("Job cancelled or completed")
                 state = self.client.get_status(job)
                 if state == "allocated":
                     unallocated.remove(job)
@@ -77,6 +80,18 @@ class Multi:
                 )
 
         self.save_job_list_file()
+
+    def this_job_complete(self):
+        """
+        If the job is complete, or cancelled, then we need to exit the
+        provision phase, and cleanup the subordinate jobs
+        """
+
+        job_id = self.job_data.get("job_id")
+        status = self.client.get_status(job_id)
+        if status in ("cancelled", "completed"):
+            return True
+        return False
 
     def save_job_list_file(self):
         """

--- a/src/snappy_device_agents/devices/multi/tests/test_multi.py
+++ b/src/snappy_device_agents/devices/multi/tests/test_multi.py
@@ -42,3 +42,22 @@ def test_inject_allocate_data():
     test_agent.create_jobs()
     for job in test_agent.job_data["provision_data"]["jobs"]:
         assert job["allocate_data"]["allocate"] is True
+
+
+def test_inject_parent_jobid():
+    """Test that parent_jobid is injected into job"""
+    test_config = {"agent_name": "test_agent"}
+    parent_job_id = "11111111-1111-1111-1111-111111111111"
+    job_data = {
+        "job_id": parent_job_id,
+        "provision_data": {
+            "jobs": [
+                {"job_id": "1"},
+                {"job_id": "2"},
+            ]
+        },
+    }
+    test_agent = Multi(test_config, job_data, MockTFClient("http://localhost"))
+    test_agent.create_jobs()
+    for job in test_agent.job_data["provision_data"]["jobs"]:
+        assert job["parent_job_id"] == parent_job_id

--- a/src/snappy_device_agents/devices/multi/tests/test_multi.py
+++ b/src/snappy_device_agents/devices/multi/tests/test_multi.py
@@ -62,8 +62,9 @@ def test_inject_parent_jobid():
     for job in test_agent.job_data["provision_data"]["jobs"]:
         assert job["parent_job_id"] == parent_job_id
 
+
 def test_this_job_complete():
-    """Test that this_job_complete returns True only when the job is complete"""
+    """Test this_job_complete() returns True only when the job is complete"""
     test_config = {"agent_name": "test_agent"}
     job_data = {
         "job_id": "11111111-1111-1111-1111-111111111111",


### PR DESCRIPTION
This is to provide the parent job_id inside the subordinate job so that the testflinger agent can watch it and exit normally if the parent job is cancelled or completed. It's not the whole fix, but it's required in order to fix issue #50 
Fixes #50 