### PR TITLE
Minor refactor to address self.client.submit_job(job) raising UnboundLocalError

### DIFF
--- a/src/snappy_device_agents/devices/multi/multi.py
+++ b/src/snappy_device_agents/devices/multi/multi.py
@@ -146,14 +146,14 @@ class Multi:
             try:
                 job_id = self.client.submit_job(job)
             except OSError as exc:
-                logger.exception("Unable to create job: %s", job_id)
+                logger.exception("Unable to create job: %s", job)
                 self.cancel_jobs(self.jobs)
                 raise ProvisioningError(
-                    f"Unable to create job: {job_id}"
+                    f"Unable to create job: {job}"
                 ) from exc
-
-            logger.info("Created job %s", job_id)
-            self.jobs.append(job_id)
+            else:
+                logger.info("Created job %s", job_id)
+                self.jobs.append(job_id)
 
     def inject_allocate_data(self, job):
         """Inject the allocate_data section into the job


### PR DESCRIPTION
Minor refactor in try, except block (146): when self.client.submit_job(job) raises an OSError, job_id is unassigned resulting in UnboundLocalError. This was brought to my attention this morning and I wanted to quickly address it.
Using job in place of job_id in the except block seemed appropriate as it's referencing a returned job_id two line above.