### PR TITLE
Raise an exception if server URL isn't specified for multi-agent

### DIFF
--- a/src/snappy_device_agents/devices/multi/tests/test_multi.py
+++ b/src/snappy_device_agents/devices/multi/tests/test_multi.py
@@ -15,6 +15,8 @@
 """Unit tests for multi-device support code."""
 
 from uuid import uuid4
+
+import pytest
 from snappy_device_agents.devices.multi.multi import Multi
 from snappy_device_agents.devices.multi.tfclient import TFClient
 
@@ -25,6 +27,14 @@ class MockTFClient(TFClient):
     def submit_job(self, job_data):
         """Return a fake job id"""
         return str(uuid4())
+
+
+def test_bad_tfclient_url():
+    """Test that Multi raises an exception when TFClient URL is bad"""
+    with pytest.raises(ValueError):
+        TFClient(None)
+    with pytest.raises(ValueError):
+        TFClient("foo.com")
 
 
 def test_inject_allocate_data():

--- a/src/snappy_device_agents/devices/multi/tfclient.py
+++ b/src/snappy_device_agents/devices/multi/tfclient.py
@@ -30,6 +30,11 @@ class TFClient:
 
         :param url: URL of the Testflinger server
         """
+        if not url or not url.startswith("http"):
+            raise ValueError(
+                "Config item testflinger_server URL for multi-device agents"
+                " must be specified and must start with http or https!"
+            )
         self.server = url
 
     def get(self, uri_frag, timeout=15):


### PR DESCRIPTION
Fix a potential config issues noticed by Adrian and Alex
Unit tests included.