### PR TITLE
fixes the following issues: 74, 76, 77. Now successfully applies capt…

### DIFF
--- a/src/snappy_device_agents/devices/maas2/maas2.py
+++ b/src/snappy_device_agents/devices/maas2/maas2.py
@@ -238,7 +238,7 @@ class Maas2:
         self.recover()
         status = self.node_status()
         # do not process an empty dataset
-        if storage_data:
+        if storage_data is not None:
             try:
                 self.maas_storage.configure_node_storage(storage_data)
             except MaasStorageError as error:
@@ -248,6 +248,7 @@ class Maas2:
                 raise ProvisioningError from error
         else:
             def_storage_data = self.config.get("default_disks")
+            self._logger_debug(f"Using def storage data: {def_storage_data}")
             if not def_storage_data:
                 self._logger_warning(
                     "'default_disks' and/or 'disks' unspecified; "

--- a/src/snappy_device_agents/devices/maas2/maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/maas_storage.py
@@ -372,10 +372,7 @@ class MaasStorage:
         """
         children = []
         for dev in self.device_list:
-            if (
-                "parent_disk" in dev
-                and dev["parent_disk"] == parent_device["id"]
-            ):
+            if dev.get("parent_disk") == parent_device["id"]:
                 children.append(dev)
         return children
 
@@ -503,20 +500,21 @@ class MaasStorage:
                     f"label={device['label']}",
                 ]
             )
+            return
+
         # if the device does not have a 'volume' key, it's a block device
-        else:
-            self.call_cmd(
-                [
-                    "maas",
-                    self.maas_user,
-                    "partition",
-                    "format",
-                    self.node_id,
-                    device["parent_disk_blkid"],
-                    f"fstype={device['fstype']}",
-                    f"label={device['label']}",
-                ]
-            )
+        self.call_cmd(
+            [
+                "maas",
+                self.maas_user,
+                "partition",
+                "format",
+                self.node_id,
+                device["parent_disk_blkid"],
+                f"fstype={device['fstype']}",
+                f"label={device['label']}",
+            ]
+        )
 
     def _get_mount_partition_id(self, device):
         """Get the partition ID from the specified mount path.

--- a/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
@@ -484,22 +484,22 @@ class TestMaasStorage:
                 expected_error, match=r"Unable to find partition ID for volume"
             ):
                 maas_storage.process_format(device)
-        else:
-            maas_storage.process_format(device)
 
-            maas_storage.call_cmd_mock.assert_called_with(
-                [
-                    "maas",
-                    maas_storage.maas_user,
-                    "partition",
-                    "format",
-                    maas_storage.node_id,
-                    device["parent_disk_blkid"],
-                    partition_id,
-                    f"fstype={device['fstype']}",
-                    f"label={device['label']}",
-                ]
-            )
+        maas_storage.process_format(device)
+
+        maas_storage.call_cmd_mock.assert_called_with(
+            [
+                "maas",
+                maas_storage.maas_user,
+                "partition",
+                "format",
+                maas_storage.node_id,
+                device["parent_disk_blkid"],
+                partition_id,
+                f"fstype={device['fstype']}",
+                f"label={device['label']}",
+            ]
+        )
 
     def test_process_mount(self, maas_storage):
         """Checks if 'process_mount' correctly processes a 'mount'

--- a/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
@@ -458,8 +458,8 @@ class TestMaasStorage:
         "partition_id, expected_error",
         [
             (2, None),  # Valid partition ID
-            (None, MaasStorageError)  # Invalid partition ID
-        ]
+            (None, MaasStorageError),  # Invalid partition ID
+        ],
     )
     def test_process_format(self, maas_storage, partition_id, expected_error):
         """Checks if 'process_format' correctly processes a 'format'

--- a/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
@@ -487,7 +487,6 @@ class TestMaasStorage:
         else:
             maas_storage.process_format(device)
 
-            # Add other assertions for the valid case here...
             maas_storage.call_cmd_mock.assert_called_with(
                 [
                     "maas",

--- a/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
@@ -454,9 +454,16 @@ class TestMaasStorage:
 
         assert device["partition_id"] == "3"
 
-    def test_process_format(self, maas_storage):
+    @pytest.mark.parametrize(
+        "partition_id, expected_error",
+        [
+            (2, None),  # Valid partition ID
+            (None, MaasStorageError)  # Invalid partition ID
+        ]
+    )
+    def test_process_format(self, maas_storage, partition_id, expected_error):
         """Checks if 'process_format' correctly processes a 'format'
-        device type.
+        device type, with and without a valid 'volume' attribute.
         """
         device = {
             "id": 4,
@@ -468,27 +475,32 @@ class TestMaasStorage:
             "volume": "volume",
         }
 
-        maas_storage._get_format_partition_id = MagicMock(return_value=2)
-
-        maas_storage.process_format(device)
-
-        maas_storage._get_format_partition_id.assert_called_with(
-            device["volume"]
+        maas_storage._get_format_partition_id = MagicMock(
+            return_value=partition_id
         )
 
-        maas_storage.call_cmd_mock.assert_called_with(
-            [
-                "maas",
-                maas_storage.maas_user,
-                "partition",
-                "format",
-                maas_storage.node_id,
-                device["parent_disk_blkid"],
-                2,
-                f"fstype={device['fstype']}",
-                f"label={device['label']}",
-            ]
-        )
+        if expected_error:
+            with pytest.raises(
+                expected_error, match=r"Unable to find partition ID for volume"
+            ):
+                maas_storage.process_format(device)
+        else:
+            maas_storage.process_format(device)
+
+            # Add other assertions for the valid case here...
+            maas_storage.call_cmd_mock.assert_called_with(
+                [
+                    "maas",
+                    maas_storage.maas_user,
+                    "partition",
+                    "format",
+                    maas_storage.node_id,
+                    device["parent_disk_blkid"],
+                    partition_id,
+                    f"fstype={device['fstype']}",
+                    f"label={device['label']}",
+                ]
+            )
 
     def test_process_mount(self, maas_storage):
         """Checks if 'process_mount' correctly processes a 'mount'

--- a/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
+++ b/src/snappy_device_agents/devices/maas2/tests/test_maas_storage.py
@@ -484,22 +484,21 @@ class TestMaasStorage:
                 expected_error, match=r"Unable to find partition ID for volume"
             ):
                 maas_storage.process_format(device)
-
-        maas_storage.process_format(device)
-
-        maas_storage.call_cmd_mock.assert_called_with(
-            [
-                "maas",
-                maas_storage.maas_user,
-                "partition",
-                "format",
-                maas_storage.node_id,
-                device["parent_disk_blkid"],
-                partition_id,
-                f"fstype={device['fstype']}",
-                f"label={device['label']}",
-            ]
-        )
+        else:
+            maas_storage.process_format(device)
+            maas_storage.call_cmd_mock.assert_called_with(
+                [
+                    "maas",
+                    maas_storage.maas_user,
+                    "partition",
+                    "format",
+                    maas_storage.node_id,
+                    device["parent_disk_blkid"],
+                    partition_id,
+                    f"fstype={device['fstype']}",
+                    f"label={device['label']}",
+                ]
+            )
 
     def test_process_mount(self, maas_storage):
         """Checks if 'process_mount' correctly processes a 'mount'


### PR DESCRIPTION
…ured default configs.

This addresses the problems presented with processing captured default configs. Ensure we do not process empty disk: datasets in a SUT config.

Tested and ensured we can now cycle between default configs, or a user supplied config without any additional issues.