### PR TITLE
rename omitted DeviceAgent

### DIFF
--- a/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
+++ b/src/testflinger_device_connectors/devices/dell_oemscript/__init__.py
@@ -35,7 +35,7 @@ from .dell_oemscript import DellOemScript
 device_name = "dell_oemscript"
 
 
-class DeviceAgent(DefaultDevice):
+class DeviceConnector(DefaultDevice):
 
     """Tool for provisioning Dell OEM devices with an oem image."""
 

--- a/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
+++ b/src/testflinger_device_connectors/devices/lenovo_oemscript/__init__.py
@@ -35,7 +35,7 @@ from .lenovo_oemscript import LenovoOemScript
 device_name = "lenovo_oemscript"
 
 
-class DeviceAgent(DefaultDevice):
+class DeviceConnector(DefaultDevice):
 
     """Tool for provisioning Lenovo OEM devices with an oem image."""
 


### PR DESCRIPTION
Renaming DeviceAgent to DeviceConnector for lenovo_oemscript and dell_oemscript to pass [load_devices()](https://github.com/canonical/snappy-device-agents/blob/d7e0370346ed8a5a94594f5701f70f622f80def9/src/testflinger_device_connectors/devices/__init__.py#L288).
