### PR TITLE
Add firmware_update phase

### DIFF
--- a/src/testflinger_device_connectors/cmd.py
+++ b/src/testflinger_device_connectors/cmd.py
@@ -39,6 +39,7 @@ def main():
         cmd_subparser = dev_subparser.add_subparsers()
         for cmd, func in (
             ("provision", dev_module.provision),
+            ("firmware_update", dev_module.firmware_update),
             ("runtest", dev_module.runtest),
             ("allocate", dev_module.allocate),
             ("reserve", dev_module.reserve),

--- a/src/testflinger_device_connectors/devices/__init__.py
+++ b/src/testflinger_device_connectors/devices/__init__.py
@@ -347,4 +347,3 @@ def load_devices():
 
 if __name__ == "__main__":
     load_devices()
-

--- a/src/testflinger_device_connectors/devices/__init__.py
+++ b/src/testflinger_device_connectors/devices/__init__.py
@@ -26,6 +26,7 @@ from datetime import datetime, timedelta
 import yaml
 
 import testflinger_device_connectors
+from testflinger_device_connectors.fw_devices.firmware_update import detect_device
 
 
 class ProvisioningError(Exception):
@@ -115,6 +116,56 @@ class RealSerialLogger:
 
 
 class DefaultDevice:
+    def firmware_update(self, args):
+        """Default method for processing firmware update commands"""
+        with open(args.config) as configfile:
+            config = yaml.safe_load(configfile)
+        testflinger_device_connectors.configure_logging(config)
+        testflinger_device_connectors.logmsg(logging.INFO, "BEGIN firmware_update")
+
+        test_opportunity = testflinger_device_connectors.get_test_opportunity(
+            args.job_data
+        )
+        fw_config = test_opportunity.get("firmware_update_data")
+        ignore_failure = fw_config.get("ignore_failure", "False")
+        exitcode = 0
+        device_ip = config["device_ip"]
+        target_device_username = "ubuntu"
+        bmc_ip = config.get("bmc_ip", None)
+        bmc_user = config.get("bmc_user", None)
+        bmc_password = config.get("bmc_password", None)
+        try:
+            if bmc_ip and bmc_user and bmc_password:
+                target_device = detect_device(
+                    device_ip,
+                    target_device_username,
+                    options={
+                        "bmc_ip": bmc_ip,
+                        "bmc_user": bmc_user,
+                        "bmc_password": bmc_password,
+                    },
+                )
+            else:
+                target_device = detect_device(device_ip, target_device_username)
+
+            target_device.get_fw_info()
+
+            if fw_config["version"] == "latest":
+                reboot_required = target_device.upgrade()
+            else:
+                reboot_required = target_device.downgrade()
+            if reboot_required:
+                target_device.reboot()
+                update_succeeded = target_device.check_results()
+                if not update_succeeded:
+                    exitcode = 1
+        except Exception as e:
+            exitcode = 1
+        if ignore_failure == "True":
+            exitcode = 0
+        testflinger_device_connectors.logmsg(logging.INFO, "END firmware_update")
+        return exitcode
+
     def runtest(self, args):
         """Default method for processing test commands"""
         with open(args.config) as configfile:

--- a/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -69,7 +69,7 @@ class LVFSDevice(AbstractDevice):
         logmsg(logging.INFO, "collect firmware info")
         self.run_cmd("sudo fwupdmgr refresh --force")
         rc, stdout, stderr = self.run_cmd("sudo fwupdmgr get-devices --json")
-        logmsg(logging.DEBUG,f"$fwupdmgr get-devices = \n{stdout}")
+        logmsg(logging.DEBUG, f"$fwupdmgr get-devices = \n{stdout}")
         self._parse_fwupd_raw(stdout)
 
     def _install_fwupd(self):
@@ -138,7 +138,6 @@ class LVFSDevice(AbstractDevice):
                         logging.INFO,
                         f"[{dev_name}] try upgrading to {latest_ver['Version']}",
                     )
-                    
                     dev["targetVersion"] = latest_ver["Version"]
                     rc, stdout, stderr = self.run_cmd(
                         f"sudo fwupdmgr upgrade {dev['DeviceId']} -y --no-reboot-check",
@@ -196,7 +195,8 @@ class LVFSDevice(AbstractDevice):
                         rc == 0 or (rc == 1 and "already exists" in stderr)
                     ):
                         raise RuntimeError(
-                            f"[{dev_name}] fail to download firmware file from LVFS\ntarget: {prev_ver['Uri']}\nerror: {stdout}"
+                            f"[{dev_name}] fail to download firmware file from LVFS"
+                            f"target: {prev_ver['Uri']}\nerror: {stdout}"
                         )
                     rc, stdout, stderr = self.run_cmd(
                         f"sudo fwupdmgr install {fw_file} -y --no-reboot-check --allow-older",
@@ -207,7 +207,7 @@ class LVFSDevice(AbstractDevice):
                         reboot = True
                     else:
                         logmsg(
-                            logging.ERROR, 
+                            logging.ERROR,
                             f"[{dev_name}] fail to force install (downgrade) firmware {fw_file}",
                         )
                         logmsg(logging.DEBUG, stdout)
@@ -278,7 +278,10 @@ class LVFSDevice(AbstractDevice):
 
         :param timeout: wait time for regaining DUT access
         """
-        logmsg(logging.INFO, f"check and wait for {timeout}s until SSH is connectable")
+        logmsg(
+            logging.INFO,
+            f"check and wait for {timeout}s until {self.ipaddr} is SSHable",
+        )
         status = "1"
         timeout_start = time.time()
 
@@ -302,11 +305,3 @@ class LVFSDevice(AbstractDevice):
         time.sleep(10)
         self.check_connectable(self.reboot_timeout)
 
-
-class LenovoNB(LVFSDevice):
-    """
-    Place-holder for device class for Lenovo Notebook devices which requires
-    battery attached for flashing firmware
-    """
-    fw_update_type = "LVFS-ext"
-    vendor = ["LENOVO"]

--- a/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/LVFS.py
@@ -1,0 +1,312 @@
+"""Device class for flashing firmware on device supported by LVFS-fwupd"""
+
+
+import subprocess
+import json
+import time
+import logging
+from typing import Tuple
+from testflinger_device_connectors.fw_devices.base import AbstractDevice
+from testflinger_device_connectors import logmsg
+
+
+SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+
+
+class LVFSDevice(AbstractDevice):
+    """Device class for devices supported by LVFS-fwupd"""
+
+    fw_update_type = "LVFS"
+    vendor = ["HP", "Dell Inc.", "LENOVO"]
+    reboot_timeout = 900
+
+    def run_cmd(
+        self, cmd: str, raise_stderr: bool = True, timeout: int = 30
+    ) -> Tuple[int, str, str]:
+        """
+        Execute command on the DUT via SSH
+
+        :param cmd:          command to run on the DUT
+        :param raise_stderr: when set to `True`, raise RuntimeError if return
+                             code != 0, otherwise ignore it
+        :param timeout:      timeout for the command response
+        :returns:            return code, stdout, stderr
+        """
+        if self.password == "":
+            ssh_cmd = f'ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
+        else:
+            ssh_cmd = f'sshpass -p {self.password}  ssh -t {SSH_OPTS} {self.user}@{self.ipaddr} "{cmd}"'
+        logmsg(logging.DEBUG, f"Run command on DUT: {ssh_cmd}")
+        try:
+            r = subprocess.run(
+                ssh_cmd,
+                shell=True,
+                capture_output=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as e:
+            if raise_stderr:
+                raise e
+            else:
+                return 124, f"command timeout after {timeout}s", ""
+        rc, stdout, stderr = (
+            r.returncode,
+            r.stdout.decode().strip(),
+            r.stderr.decode().strip(),
+        )
+        if raise_stderr and rc != 0:
+            err_msg = f"Failed to execute {cmd}:\n [{rc}] {stdout} {stderr}"
+            logmsg(logging.DEBUG, err_msg)
+            raise RuntimeError(err_msg)
+        return rc, stdout, stderr
+
+    def get_fw_info(self):
+        """
+        Get current firmware version of all updatable devices on DUT, and print
+        out devices with upgradable/downgradable versions
+        """
+        self._install_fwupd()
+        logmsg(logging.INFO, "collect firmware info")
+        self.run_cmd("sudo fwupdmgr refresh --force")
+        rc, stdout, stderr = self.run_cmd("sudo fwupdmgr get-devices --json")
+        logmsg(logging.DEBUG,f"$fwupdmgr get-devices = \n{stdout}")
+        self._parse_fwupd_raw(stdout)
+
+    def _install_fwupd(self):
+        self.run_cmd("sudo apt update", raise_stderr=False, timeout=120)
+        self.run_cmd("sudo apt install -y fwupd")
+        rc, stdout, stderr = self.run_cmd("sudo fwupdmgr --version")
+        logmsg(logging.DEBUG, stdout)
+
+    def _parse_fwupd_raw(self, fwupd_raw: str) -> bool:
+        """
+        Parse the output of ```$ fwupdmgr get-devices```
+
+        :param fwupd_raw: output string of ```$ fwupdmgr get-devices```
+        """
+        for dev in json.loads(fwupd_raw)["Devices"]:
+            if "Flags" in dev and "updatable" in dev["Flags"]:
+                self.fw_info.append(dev)
+
+        for dev in self.fw_info:
+            if "Version" in dev:
+                dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+                msg = f"[{dev_name}] current version: {dev['Version']}"
+            else:
+                msg = ""
+            if "Releases" in dev:
+                higher_ver, lower_ver, same_ver = [], [], []
+                vers = ""
+                for rel in dev["Releases"]:
+                    if "Flags" not in rel:
+                        continue
+                    elif "is-upgrade" in rel["Flags"]:
+                        higher_ver.append(rel["Version"])
+                    elif "is-downgrade" in rel["Flags"]:
+                        lower_ver.append(rel["Version"])
+                    else:
+                        same_ver.append(rel["Version"])
+                if higher_ver != []:
+                    vers = f" - LVFS upgradable version(s): {', '.join(higher_ver)}"
+                if lower_ver != []:
+                    vers += f" - LVFS downgradable version(s): {', '.join(lower_ver)}"
+                if vers:
+                    msg += vers
+            else:
+                msg += " - no available firmware on LVFS"
+            if msg:
+                logmsg(logging.INFO, msg)
+
+    def upgrade(self) -> bool:
+        """
+        Upgrade all devices firmware to latest version if available on LVFS
+
+        :return: `True` if upgrading is done and reboot is required, `False`
+                 otherwise
+        """
+        logmsg(logging.INFO, "start upgrading")
+        reboot = False
+        for dev in self.fw_info:
+            dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+            try:
+                latest_ver = dev["Releases"][0]
+            except KeyError:
+                continue
+            if dev["Version"] != latest_ver["Version"]:
+                if "is-upgrade" in latest_ver["Flags"]:
+                    logmsg(
+                        logging.INFO,
+                        f"[{dev_name}] try upgrading to {latest_ver['Version']}",
+                    )
+                    
+                    dev["targetVersion"] = latest_ver["Version"]
+                    rc, stdout, stderr = self.run_cmd(
+                        f"sudo fwupdmgr upgrade {dev['DeviceId']} -y --no-reboot-check",
+                        raise_stderr=False,
+                    )
+                    if rc == 0:
+                        logmsg(logging.DEBUG, stdout)
+                        reboot = True
+                    else:
+                        logmsg(
+                            logging.ERROR,
+                            f"[{dev_name}] Failed to upgrade to {latest_ver['Version']}",
+                        )
+                        logmsg(logging.DEBUG, stdout)
+                else:
+                    logmsg(
+                        logging.DEBUG,
+                        f"[{dev_name}] unsupported Flags: {str(latest_ver['Flags'])}",
+                    )
+            else:
+                logmsg(
+                    logging.INFO,
+                    f"[{dev_name}] already the latest available firmware version",
+                )
+        return reboot
+
+    def downgrade(self) -> bool:
+        """
+        Downgrade all devices firmware to 2nd new version if available on LVFS
+
+        :return: `True` if downgrading is done and reboot is required, `False`
+                 otherwise
+        """
+        logmsg(logging.INFO, "start downgrading")
+        reboot = False
+        for dev in self.fw_info:
+            dev_name = dev["Name"] if "Name" in dev else dev["DeviceId"]
+            try:
+                prev_ver = dev["Releases"][1]
+            except (KeyError, IndexError):
+                continue
+            if dev["Version"] != prev_ver["Version"]:
+                if "is-downgrade" in prev_ver["Flags"]:
+                    dev["targetVersion"] = prev_ver["Version"]
+                    fw_file = prev_ver["Uri"].split("/")[-1]
+                    logmsg(
+                        logging.INFO,
+                        f"[{dev_name}] try downgrading to {prev_ver['Version']}",
+                    )
+                    rc, stdout, stderr = self.run_cmd(
+                        f"sudo fwupdmgr download {prev_ver['Uri']}",
+                        raise_stderr=False,
+                    )
+                    if not (
+                        rc == 0 or (rc == 1 and "already exists" in stderr)
+                    ):
+                        raise RuntimeError(
+                            f"[{dev_name}] fail to download firmware file from LVFS\ntarget: {prev_ver['Uri']}\nerror: {stdout}"
+                        )
+                    rc, stdout, stderr = self.run_cmd(
+                        f"sudo fwupdmgr install {fw_file} -y --no-reboot-check --allow-older",
+                        raise_stderr=False,
+                    )
+                    if rc == 0:
+                        logmsg(logging.DEBUG, stdout)
+                        reboot = True
+                    else:
+                        logmsg(
+                            logging.ERROR, 
+                            f"[{dev_name}] fail to force install (downgrade) firmware {fw_file}",
+                        )
+                        logmsg(logging.DEBUG, stdout)
+                else:
+                    logmsg(
+                        logging.DEBUG,
+                        f"[{dev_name}] unsupported Flags: {prev_ver['Flags']}",
+                    )
+            else:
+                logmsg(
+                    logging.INFO,
+                    f"[{dev_name}] already the previous version",
+                )
+        return reboot
+
+    def check_results(self) -> bool:
+        """
+        Get upgrade/downgrade result and validate if it succeeds
+
+        :return: `True` if overall upgrade status is success, `False` otherwise
+        """
+        fwupd_result = True
+        for dev in self.fw_info:
+            try:
+                dev_name = dev["Name"]
+            except KeyError:
+                dev_name = dev["DeviceId"]
+            try:
+                expected_ver = dev["targetVersion"]
+            except KeyError:
+                continue
+            rc, stdout, stderr = self.run_cmd(
+                f"sudo fwupdmgr get-results {dev['DeviceId']} --json"
+            )
+            get_results = json.loads(stdout)
+            logmsg(logging.DEBUG, f"$fwupdmgr get-result = {stdout}%s")
+            try:
+                new_fw = get_results["Releases"][0]
+                update_state = get_results["UpdateState"]
+            except KeyError:
+                msg = f"[{dev_name}] unable to determine if new firmware is landed due to missing results"
+                logmsg(logging.INFO, msg)
+                fwupd_result = False
+                continue
+
+            if new_fw["Version"] == expected_ver and update_state == 2:
+                msg = f"[{dev_name}] firmware flashed {dev['Version']} → {expected_ver}"
+            else:
+                FwupdUpdateState = [
+                    "FWUPD_UPDATE_STATE_UNKNOWN",
+                    "FWUPD_UPDATE_STATE_PENDING",
+                    "FWUPD_UPDATE_STATE_SUCCESS",
+                    "FWUPD_UPDATE_STATE_FAILED",
+                    "FWUPD_UPDATE_STATE_NEEDS_REBOOT",
+                    "FWUPD_UPDATE_STATE_FAILED_TRANSIENT",
+                    "FWUPD_UPDATE_STATE_LAST",
+                ]
+                update_err = get_results.get("UpdateError", "")
+                msg = f"[{dev_name}] {FwupdUpdateState[update_state]}: {update_err}"
+                fwupd_result = False
+            logmsg(logging.INFO, msg)
+
+        return fwupd_result
+
+    def check_connectable(self, timeout: int):
+        """
+        After DUT reboot, check if SSH to DUT works within a given timeout period
+
+        :param timeout: wait time for regaining DUT access
+        """
+        logmsg(logging.INFO, f"check and wait for {timeout}s until SSH is connectable")
+        status = "1"
+        timeout_start = time.time()
+
+        while status != "0" and time.time() < timeout_start + timeout:
+            status = subprocess.check_output(
+                f"timeout 10 ssh {SSH_OPTS} {self.user}@{self.ipaddr} /bin/true 2>/dev/null; echo $?",
+                shell=True,
+                universal_newlines=True,
+            ).strip()
+        if status != "0" and status != "124":
+            err_msg = f"Failed to SSH to {self.ipaddr} after {timeout}s"
+            logmsg(logging.ERROR, err_msg)
+            raise RuntimeError(err_msg)
+        delta = time.time() - timeout_start
+        logmsg(logging.INFO, f"{self.ipaddr} is SSHable after {int(delta)}s")
+
+    def reboot(self):
+        """Reboot the DUT from OS"""
+        logmsg(logging.INFO, "reboot DUT")
+        self.run_cmd("sudo reboot", raise_stderr=False)
+        time.sleep(10)
+        self.check_connectable(self.reboot_timeout)
+
+
+class LenovoNB(LVFSDevice):
+    """
+    Place-holder for device class for Lenovo Notebook devices which requires
+    battery attached for flashing firmware
+    """
+    fw_update_type = "LVFS-ext"
+    vendor = ["LENOVO"]

--- a/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
@@ -1,0 +1,387 @@
+""" fwupdmgr json outputs """
+
+
+GET_RESULTS_RESPONSE_DATA = """{
+  "Name" : "System Firmware",
+  "DeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+  "Guid" : [
+    "37c94477-30f8-42df-96f9-5e417cc49274"
+  ],
+  "Plugin" : "uefi_capsule",
+  "Flags" : [
+    "internal",
+    "updatable",
+    "require-ac",
+    "needs-reboot",
+    "historical",
+    "can-verify",
+    "usable-during-update"
+  ],
+  "Checksums" : [
+    "d655d59f250f7e15a90afb08f348ae428b9a37c1"
+  ],
+  "Version" : "2.91",
+  "Created" : 1694166016,
+  "Modified" : 1694166169,
+  "UpdateState" : 2,
+  "Releases" : [
+    {
+      "Version" : "2.90",
+      "Checksum" : [
+        "6232b2a43b22966b179f9b5a8f459731c37d7b8f"
+      ],
+      "LastAttemptVersion" : "0x2005a",
+      "TpmFamily" : "2.0",
+      "LastAttemptStatus" : "0x0",
+      "RuntimeVersion(org.kernel)" : "5.10.0-1023-oem",
+      "DistroVersion" : "20.04",
+      "RuntimeVersion(org.freedesktop.fwupd)" : "1.7.9",
+      "Pcr0_SHA1" : "d655d59f250f7e15a90afb08f348ae428b9a37c1",
+      "UEFIUXCapsule" : "Enabled",
+      "CpuArchitecture" : "x86_64",
+      "SecureBoot" : "Disabled",
+      "HostFamily" : "103C_53335X HP Workstation",
+      "HostVendor" : "HP",
+      "RuntimeVersion(org.freedesktop.gusb)" : "0.3.4",
+      "FwupdTainted" : "False",
+      "RuntimeVersion(com.dell.libsmbios)" : "2.4",
+      "MissingCapsuleHeader" : "False",
+      "CompileVersion(org.freedesktop.gusb)" : "0.3.4",
+      "FwupdSupported" : "True",
+      "KernelVersion" : "5.10.0-1023-oem",
+      "TpmEventLog" : "0x00000008 88f88963e20ba2063edbf78215e9f90f37c551cd",
+      "EspPath" : "/boot/efi",
+      "HostProduct" : "HP Z4 G4 Workstation",
+      "BootTime" : "1694165999",
+      "KernelName" : "Linux",
+      "CapsuleApplyMethod" : "nvram",
+      "LinuxLockdown" : "none",
+      "CompileVersion(com.hughsie.libjcat)" : "0.1.4",
+      "Pcr0_SHA256" : "580aaf47328accd895515cc0143903c7e88579769d319a511ca9567575bd547f",
+      "EfivarNvramUsed" : "100530",
+      "KernelCmdline" : "automatic-oem-config",
+      "DistroId" : "ubuntu",
+      "CompileVersion(org.freedesktop.fwupd)" : "1.7.9",
+      "HostSku" : "8DZ51UT#ABA"
+    }
+  ]
+}
+"""
+
+GET_RESULTS_ERROR_RESPONSE_DATA = """
+{
+  "Error" : {
+    "Domain" : "FwupdError",
+    "Code" : 9,
+    "Message" : "Failed to find 4bde70ba4e39b28f9eab1628f9dd6e6244c03027 in history database: No devices found"
+  }
+}
+"""
+
+GET_DEVICES_RESPONSE_DATA = """{
+  "Devices" : [
+    {
+      "Name" : "Core™ i7-9800X CPU @ 3.80GHz",
+      "DeviceId" : "4bde70ba4e39b28f9eab1628f9dd6e6244c03027",
+      "Guid" : [
+        "b9a2dd81-159e-5537-a7db-e7101d164d3f",
+        "30249f37-d140-5d3e-9319-186b1bd5cac3",
+        "aeac0d3d-a127-52d8-9745-891104b2ec28",
+        "1c7713d4-3bd2-5032-b9cc-291671aba257"
+      ],
+      "Plugin" : "cpu",
+      "Flags" : [
+        "internal",
+        "registered"
+      ],
+      "Vendor" : "Intel",
+      "VersionFormat" : "hex",
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "DVDRW GUD1N",
+      "DeviceId" : "612faa85309fec62ddfdce9f4635cdfef838d74e",
+      "Guid" : [
+        "bcb713aa-ecde-5359-a2e5-49fe84787374",
+        "57ac0a58-5421-53ce-ac80-4566d4e1e6e3"
+      ],
+      "Summary" : "SCSI device",
+      "Plugin" : "scsi",
+      "Flags" : [
+        "registered"
+      ],
+      "Vendor" : "hp HLDS",
+      "VendorId" : "SCSI:hp-HLDS",
+      "Version" : "LD06",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "GP104GL [Quadro P5000]",
+      "DeviceId" : "3c07caee1bce434f1160c260ba0a471f60d66961",
+      "Guid" : [
+        "643cf998-eaee-5c6f-b403-8370b5f04f10",
+        "0e71595a-45dd-58cc-aed4-a29cd1e0176d",
+        "38458a57-3a97-53fa-824a-ba3809471a07",
+        "0ed83a18-0bb5-590e-aae1-7d07ca60a280"
+      ],
+      "Plugin" : "optionrom",
+      "Flags" : [
+        "internal",
+        "registered",
+        "can-verify",
+        "can-verify-image"
+      ],
+      "Vendor" : "NVIDIA Corporation",
+      "VendorId" : "PCI:0x10DE",
+      "Version" : "a1",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "audio-card"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "MZVLB256HBHQ-000H1",
+      "DeviceId" : "599ead362818be284e800cbc30d4c29f934086c3",
+      "Guid" : [
+        "0b4d773a-7ac3-58c1-a541-e22ef1cdfe02",
+        "c9d531ea-ee7d-5562-8def-c64d0d144813",
+        "6e54c992-d302-59ab-b454-2d26ddd63e6d",
+        "47335265-a509-51f7-841e-1c94911af66b",
+        "e803e58a-cbd1-5b1c-b60b-dc4cd6e985d7"
+      ],
+      "Serial" : "S4GNNX0NC13964",
+      "Summary" : "NVM Express solid state drive",
+      "Plugin" : "nvme",
+      "Protocol" : "org.nvmexpress",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "require-ac",
+        "registered",
+        "needs-reboot",
+        "usable-during-update",
+        "signed-payload"
+      ],
+      "Vendor" : "Samsung",
+      "VendorId" : "NVME:0x144D",
+      "Version" : "HPS0NEXH",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "SanDisk 3.2Gen1",
+      "DeviceId" : "136108aa898cf18c2d6c51fb0d3942fcab13055b",
+      "Guid" : [
+        "9d4068a9-9553-59a2-ad7f-b19922d584b1",
+        "b861e037-c38d-56ea-adaf-b2325ee6b96b"
+      ],
+      "Summary" : "SCSI device",
+      "Plugin" : "scsi",
+      "Flags" : [
+        "registered"
+      ],
+      "Vendor" : "USB",
+      "VendorId" : "SCSI:USB",
+      "Version" : "1.00",
+      "VersionFormat" : "plain",
+      "Icons" : [
+        "drive-harddisk"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "System Firmware",
+      "DeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "Guid" : [
+        "37c94477-30f8-42df-96f9-5e417cc49274",
+        "230c8b18-8d9b-53ec-838b-6cfc0383493a"
+      ],
+      "Summary" : "UEFI ESRT device",
+      "Plugin" : "uefi_capsule",
+      "Protocol" : "org.uefi.capsule",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "require-ac",
+        "supported",
+        "registered",
+        "needs-reboot",
+        "can-verify",
+        "usable-during-update"
+      ],
+      "Checksums" : [
+        "88168c9e2b47f7560125cd6f811a9b4390f8bc70",
+        "3bc12536624150ef382938f92ca0d3d80aed712552ae89cc8957d884d9372315"
+      ],
+      "Vendor" : "HP",
+      "VendorId" : "DMI:HP",
+      "Version" : "2.90",
+      "VersionLowest" : "0.1",
+      "VersionFormat" : "pair",
+      "VersionRaw" : 131162,
+      "VersionLowestRaw" : 1,
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931,
+      "UpdateState" : 2,
+      "Releases" : [
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "28623",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.91:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>Added support for a new DIMM manufacturer.</li><li>Added support for HP Anyware Remote System Controller features.</li></ul>",
+          "Version" : "2.91",
+          "Filename" : "9af72a66c38ab97ed17f1388582eb6baa0929295",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "5ffa48e85b1bbb98a4a911643cd4a690194fee97",
+            "2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1679514694,
+          "Locations" : [
+            "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP",
+          "Flags" : [
+            "is-upgrade"
+          ]
+        },
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "22717",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.90:</p><ul><li>Added SATA hot plug support.</li><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Updates UEFI-based Hardware Diagnostics to version 2.3.2.0&gt;</li><li>Addressed changes introduced in previous BIOS which prevented a custom logo from being set.</li></ul>",
+          "Version" : "2.90",
+          "Filename" : "ba3142d342afce4c5bde21ee469871156cb8add3",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "6232b2a43b22966b179f9b5a8f459731c37d7b8f",
+            "90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1675389026,
+          "Locations" : [
+            "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP"
+        },
+        {
+          "AppstreamId" : "com.hp.workstation.P62.firmware",
+          "ReleaseId" : "14966",
+          "RemoteId" : "lvfs",
+          "Name" : "Z4 G4 Core-X Workstation",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
+          "Description" : "<p>Fixes and enhancements in P62 2.85:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Adds SMBIOS System Enclosure or Chassis (Type 3) entry.</li><li>Fixes an issue where Network BIOS Update would fail in Legacy mode.</li><li>Fixes an issue where system would not boot with a certain PCIe serial card installed.</li><li>Fixes a performance issue with a certain PCIe FireWire card.</li></ul>",
+          "Version" : "2.85",
+          "Filename" : "8e9bfcf011d2a6c38986d7bebdf5fc8b39e23bd3",
+          "Protocol" : "org.uefi.capsule",
+          "Categories" : [
+            "X-System"
+          ],
+          "Checksum" : [
+            "17fcf952384cbf17f1dce5a150303b4a38e0178b",
+            "f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d"
+          ],
+          "License" : "LicenseRef-proprietary",
+          "Size" : 16781312,
+          "Created" : 1658274892,
+          "Locations" : [
+            "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab"
+          ],
+          "Uri" : "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab",
+          "Homepage" : "http://www.hp.com/go/workstations",
+          "Vendor" : "HP",
+          "Flags" : [
+            "is-downgrade"
+          ]
+        }
+      ]
+    },
+    {
+      "Name" : "TPM",
+      "DeviceId" : "c6a80ac3a22083423992a3cb15018989f37834d6",
+      "Guid" : [
+        "ff71992e-52f7-5eea-94ef-883e56e034c6",
+        "5eebb112-75ad-5536-b173-a11eb3399402",
+        "ddf995da-1b32-5a8a-bc1b-8d5af4b38b51",
+        "6d81ab63-db2e-50ac-934f-6be9accf5e02",
+        "301555de-680d-5ddc-b995-7553fc9138f1"
+      ],
+      "Plugin" : "tpm",
+      "Flags" : [
+        "internal",
+        "registered"
+      ],
+      "Vendor" : "Infineon",
+      "VendorId" : "TPM:IFX",
+      "Version" : "7.85.17.51968",
+      "VersionFormat" : "quad",
+      "VersionRaw" : 1970689910360832,
+      "Icons" : [
+        "computer"
+      ],
+      "Created" : 1693535931
+    },
+    {
+      "Name" : "UEFI dbx",
+      "DeviceId" : "362301da643102b9f38477387e2193e57abaa590",
+      "ParentDeviceId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "CompositeId" : "a45df35ac0e948ee180fe216a5f703f32dda163f",
+      "Guid" : [
+        "20716f78-5f65-5fe7-b32b-55a6a16392ab",
+        "f1d99738-25d4-5f76-a2ec-87750d294993",
+        "c6682ade-b5ec-57c4-b687-676351208742",
+        "f8ba2887-9411-5c36-9cee-88995bb39731"
+      ],
+      "Summary" : "UEFI revocation database",
+      "Plugin" : "uefi_dbx",
+      "Protocol" : "org.uefi.dbx",
+      "Flags" : [
+        "internal",
+        "updatable",
+        "registered",
+        "needs-reboot",
+        "only-version-upgrade",
+        "signed-payload"
+      ],
+      "VendorId" : "UEFI:Linux Foundation",
+      "Version" : "239",
+      "VersionLowest" : "239",
+      "VersionFormat" : "number",
+      "Icons" : [
+        "computer"
+      ],
+      "InstallDuration" : 1,
+      "Created" : 1693535931
+    }
+  ]
+}"""

--- a/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/tests/fwupd_data.py
@@ -57,7 +57,7 @@ GET_RESULTS_RESPONSE_DATA = """{
       "CapsuleApplyMethod" : "nvram",
       "LinuxLockdown" : "none",
       "CompileVersion(com.hughsie.libjcat)" : "0.1.4",
-      "Pcr0_SHA256" : "580aaf47328accd895515cc0143903c7e88579769d319a511ca9567575bd547f",
+      "Pcr0_SHA256" : "580aaf47328accd895515cc014390",
       "EfivarNvramUsed" : "100530",
       "KernelCmdline" : "automatic-oem-config",
       "DistroId" : "ubuntu",
@@ -73,7 +73,7 @@ GET_RESULTS_ERROR_RESPONSE_DATA = """
   "Error" : {
     "Domain" : "FwupdError",
     "Code" : 9,
-    "Message" : "Failed to find 4bde70ba4e39b28f9eab1628f9dd6e6244c03027 in history database: No devices found"
+    "Message" : "Failed to find 4bde70ba4e39b28f9eab1628f9dd6e6244c03027"
   }
 }
 """
@@ -242,8 +242,8 @@ GET_DEVICES_RESPONSE_DATA = """{
           "ReleaseId" : "28623",
           "RemoteId" : "lvfs",
           "Name" : "Z4 G4 Core-X Workstation",
-          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
-          "Description" : "<p>Fixes and enhancements in P62 2.91:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>Added support for a new DIMM manufacturer.</li><li>Added support for HP Anyware Remote System Controller features.</li></ul>",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations",
+          "Description" : "<p>Fixes and enhancements in P62 2.91:</p>",
           "Version" : "2.91",
           "Filename" : "9af72a66c38ab97ed17f1388582eb6baa0929295",
           "Protocol" : "org.uefi.capsule",
@@ -258,9 +258,9 @@ GET_DEVICES_RESPONSE_DATA = """{
           "Size" : 16781312,
           "Created" : 1679514694,
           "Locations" : [
-            "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab"
+            "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a7.cab"
           ],
-          "Uri" : "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded57d355a70d1da3a02bcd12aa02b9c5ab84d8a2ee-P62_0291.cab",
+          "Uri" : "https://fwupd.org/downloads/2571fa9e4ca038aa41c86ded5.cab",
           "Homepage" : "http://www.hp.com/go/workstations",
           "Vendor" : "HP",
           "Flags" : [
@@ -272,8 +272,8 @@ GET_DEVICES_RESPONSE_DATA = """{
           "ReleaseId" : "22717",
           "RemoteId" : "lvfs",
           "Name" : "Z4 G4 Core-X Workstation",
-          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
-          "Description" : "<p>Fixes and enhancements in P62 2.90:</p><ul><li>Added SATA hot plug support.</li><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Updates UEFI-based Hardware Diagnostics to version 2.3.2.0&gt;</li><li>Addressed changes introduced in previous BIOS which prevented a custom logo from being set.</li></ul>",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations",
+          "Description" : "<p>Fixes and enhancements in P62 2.90:</p><",
           "Version" : "2.90",
           "Filename" : "ba3142d342afce4c5bde21ee469871156cb8add3",
           "Protocol" : "org.uefi.capsule",
@@ -288,9 +288,9 @@ GET_DEVICES_RESPONSE_DATA = """{
           "Size" : 16781312,
           "Created" : 1675389026,
           "Locations" : [
-            "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab"
+            "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711.cab"
           ],
-          "Uri" : "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8fb95e711ab240dfcd50b0ff82a9ebe5f4750eed6-P62_0290.cab",
+          "Uri" : "https://fwupd.org/downloads/90c505fd9b6f56311a4202d8f.cab",
           "Homepage" : "http://www.hp.com/go/workstations",
           "Vendor" : "HP"
         },
@@ -299,8 +299,8 @@ GET_DEVICES_RESPONSE_DATA = """{
           "ReleaseId" : "14966",
           "RemoteId" : "lvfs",
           "Name" : "Z4 G4 Core-X Workstation",
-          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations (Core X-series processors), family P62",
-          "Description" : "<p>Fixes and enhancements in P62 2.85:</p><ul><li>Includes enhancements to mitigate security vulnerabilities.</li><li>HP strongly recommends promptly transitioning to this updated BIOS version.</li><li>Adds SMBIOS System Enclosure or Chassis (Type 3) entry.</li><li>Fixes an issue where Network BIOS Update would fail in Legacy mode.</li><li>Fixes an issue where system would not boot with a certain PCIe serial card installed.</li><li>Fixes a performance issue with a certain PCIe FireWire card.</li></ul>",
+          "Summary" : "System Firmware (BIOS) for HP Z4 G4 Workstations",
+          "Description" : "<p>Fixes and enhancements in P62 2.85:</p>",
           "Version" : "2.85",
           "Filename" : "8e9bfcf011d2a6c38986d7bebdf5fc8b39e23bd3",
           "Protocol" : "org.uefi.capsule",
@@ -315,9 +315,9 @@ GET_DEVICES_RESPONSE_DATA = """{
           "Size" : 16781312,
           "Created" : 1658274892,
           "Locations" : [
-            "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab"
+            "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17e.cab"
           ],
-          "Uri" : "https://fwupd.org/downloads/f328b807e6318c51d531771bd9e1b17efffcad755d7ca9ac3913faa1015f340d-P62_0285.cab",
+          "Uri" : "https://fwupd.org/downloads/f328b807e6318c51d531771bd.cab",
           "Homepage" : "http://www.hp.com/go/workstations",
           "Vendor" : "HP",
           "Flags" : [

--- a/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -3,8 +3,8 @@
 
 import unittest
 import json
-from testflinger_device_connectors.fw_devices import *
 from unittest.mock import patch
+from testflinger_device_connectors.fw_devices import LVFSDevice
 from testflinger_device_connectors.fw_devices.LVFS.tests import fwupd_data
 
 device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
@@ -23,7 +23,9 @@ class TestLVFSDevice(unittest.TestCase):
         Test if upgrade function returns True. And test if downgrade function
         returns False.
         """
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
@@ -36,7 +38,9 @@ class TestLVFSDevice(unittest.TestCase):
         Test if upgrade function returns False. And test if downgrade function
         returns True.
         """
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
 
@@ -53,7 +57,9 @@ class TestLVFSDevice(unittest.TestCase):
     def test_check_results_failed_state(self):
         """Validate UpdateState check in check_results"""
         global device_results
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
@@ -65,7 +71,9 @@ class TestLVFSDevice(unittest.TestCase):
     def test_check_results_mismatched_version(self):
         """Validate version check in check_results"""
         global device_results
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
@@ -75,7 +83,9 @@ class TestLVFSDevice(unittest.TestCase):
     def test_check_results_good(self):
         """Test if check_results works with a valid case"""
         global device_results
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
@@ -91,7 +101,9 @@ class TestLVFSDevice(unittest.TestCase):
         get-results```
         """
         global device_results
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd
             device = LVFSDevice("", "", "")
             device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)

--- a/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
+++ b/src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py
@@ -1,0 +1,102 @@
+"""Test LVFSDevice"""
+
+
+import unittest
+import json
+from testflinger_device_connectors.fw_devices import *
+from unittest.mock import patch
+from testflinger_device_connectors.fw_devices.LVFS.tests import fwupd_data
+
+device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
+
+
+class TestLVFSDevice(unittest.TestCase):
+    def mock_run_cmd(*args, **kwargs):
+        """Mock run_cmd"""
+        if "sudo fwupdmgr get-results" in args[1]:
+            return 0, json.dumps(device_results), ""
+        return 0, "", ""
+
+    def test_upgradable(self):
+        """
+        Given fwupd data with only newer System Firmware releases available.
+        Test if upgrade function returns True. And test if downgrade function
+        returns False.
+        """
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            self.assertTrue(device.upgrade())
+            self.assertFalse(device.downgrade())
+
+    def test_downgradable(self):
+        """
+        Given fwupd data with only older System Firmware releases available.
+        Test if upgrade function returns False. And test if downgrade function
+        returns True.
+        """
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+
+            device_info = json.loads(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device_info["Devices"][5]["Version"] = "2.91"
+            device_info["Devices"][5]["Releases"][0]["Flags"] = []
+            device_info["Devices"][5]["Releases"][1]["Flags"] = [
+                "is-downgrade"
+            ]
+            device._parse_fwupd_raw(json.dumps(device_info))
+            self.assertFalse(device.upgrade())
+            self.assertTrue(device.downgrade())
+
+    def test_check_results_failed_state(self):
+        """Validate UpdateState check in check_results"""
+        global device_results
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device.fw_info[2]["targetVersion"] = "2.90"
+            device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
+            device_results["UpdateState"] = 3
+            self.assertFalse(device.check_results())
+
+    def test_check_results_mismatched_version(self):
+        """Validate version check in check_results"""
+        global device_results
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device.fw_info[2]["targetVersion"] = "2.91"
+            self.assertFalse(device.check_results())
+
+    def test_check_results_good(self):
+        """Test if check_results works with a valid case"""
+        global device_results
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device_results = json.loads(fwupd_data.GET_RESULTS_RESPONSE_DATA)
+            device_results["UpdateState"] = 2
+            device_results["Releases"][0]["Version"] = "2.90"
+            device.fw_info[2]["targetVersion"] = "2.90"
+            self.assertTrue(device.check_results())
+
+    def test_check_results_error(self):
+        """
+        Test error in check_results with an error return from ```$ fwupdmgr
+        get-results```
+        """
+        global device_results
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd
+            device = LVFSDevice("", "", "")
+            device._parse_fwupd_raw(fwupd_data.GET_DEVICES_RESPONSE_DATA)
+            device.fw_info[2]["targetVersion"] = "2.90"
+            device_results = json.loads(
+                fwupd_data.GET_RESULTS_ERROR_RESPONSE_DATA
+            )
+            self.assertFalse(device.check_results())

--- a/src/testflinger_device_connectors/fw_devices/OEM/OEM.py
+++ b/src/testflinger_device_connectors/fw_devices/OEM/OEM.py
@@ -1,0 +1,16 @@
+"""Device classes for flashing firmware on device with OEM-specific methods"""
+
+from testflinger_device_connectors.fw_devices.base import AbstractDevice
+
+
+class OEMDevice(AbstractDevice):
+    """Device class for devices that are not supported by LVFS-fwupd"""
+
+    fw_update_type = "OEM-defined"
+
+
+class HPEDevice(OEMDevice):
+    """Place-holder for device class for HPE server"""
+
+    fw_update_type = "OEM-defined"
+    vendor = "HPE"

--- a/src/testflinger_device_connectors/fw_devices/__init__.py
+++ b/src/testflinger_device_connectors/fw_devices/__init__.py
@@ -13,4 +13,3 @@ __all__ = [
     "HPEDevice",
     "logmsg",
 ]
-

--- a/src/testflinger_device_connectors/fw_devices/__init__.py
+++ b/src/testflinger_device_connectors/fw_devices/__init__.py
@@ -1,0 +1,13 @@
+from testflinger_device_connectors.fw_devices.base import AbstractDevice
+from testflinger_device_connectors.fw_devices.LVFS.LVFS import LVFSDevice, LenovoNB
+from testflinger_device_connectors.fw_devices.OEM.OEM import OEMDevice, HPEDevice
+from testflinger_device_connectors import logmsg
+
+__all__ = [
+    "AbstractDevice",
+    "LVFSDevice",
+    "LenovoNB",
+    "OEMDevice",
+    "HPEDevice",
+    "logmsg",
+]

--- a/src/testflinger_device_connectors/fw_devices/__init__.py
+++ b/src/testflinger_device_connectors/fw_devices/__init__.py
@@ -1,13 +1,16 @@
 from testflinger_device_connectors.fw_devices.base import AbstractDevice
-from testflinger_device_connectors.fw_devices.LVFS.LVFS import LVFSDevice, LenovoNB
-from testflinger_device_connectors.fw_devices.OEM.OEM import OEMDevice, HPEDevice
+from testflinger_device_connectors.fw_devices.LVFS.LVFS import LVFSDevice
+from testflinger_device_connectors.fw_devices.OEM.OEM import (
+    OEMDevice,
+    HPEDevice,
+)
 from testflinger_device_connectors import logmsg
 
 __all__ = [
     "AbstractDevice",
     "LVFSDevice",
-    "LenovoNB",
     "OEMDevice",
     "HPEDevice",
     "logmsg",
 ]
+

--- a/src/testflinger_device_connectors/fw_devices/base.py
+++ b/src/testflinger_device_connectors/fw_devices/base.py
@@ -42,4 +42,3 @@ class AbstractDevice(ABC):
     @abstractmethod
     def reboot(self):
         raise NotImplementedError("Please, implement the reboot method")
-

--- a/src/testflinger_device_connectors/fw_devices/base.py
+++ b/src/testflinger_device_connectors/fw_devices/base.py
@@ -1,0 +1,45 @@
+"""Base class for flashing firmware on devices"""
+
+from abc import ABC, abstractmethod
+
+
+class AbstractDevice(ABC):
+    fw_update_type = ""
+    vendor = ""
+
+    def __init__(self, ipaddr: str, user: str, password: str):
+        self.ipaddr = ipaddr
+        self.user = user
+        self.password = password
+        self.fw_info = []
+
+    @abstractmethod
+    def run_cmd(self):
+        raise NotImplementedError("Please, implement the run_cmd method")
+
+    @abstractmethod
+    def get_fw_info(self):
+        raise NotImplementedError("Please, implement the get_fw_info method")
+
+    @abstractmethod
+    def upgrade(self):
+        raise NotImplementedError("Please, implement the upgrade method")
+
+    @abstractmethod
+    def downgrade(self):
+        raise NotImplementedError("Please, implement the downgrade method")
+
+    @abstractmethod
+    def check_results(self):
+        raise NotImplementedError("Please, implement the check_results method")
+
+    @abstractmethod
+    def check_connectable(self):
+        raise NotImplementedError(
+            "Please, implement the check_connectable method"
+        )
+
+    @abstractmethod
+    def reboot(self):
+        raise NotImplementedError("Please, implement the reboot method")
+

--- a/src/testflinger_device_connectors/fw_devices/dmi.py
+++ b/src/testflinger_device_connectors/fw_devices/dmi.py
@@ -1,0 +1,47 @@
+"""This maps DMI chassis type to readable name"""
+
+
+class Dmi:
+    chassis = (
+        ("Undefined", "unknown"),  # 0x00
+        ("Other", "unknown"),  # 0x01
+        ("Unknown", "unknown"),
+        ("Desktop", "LVFS"),  # 0x03
+        ("Low Profile Desktop", "unknown"),
+        ("Pizza Box", "unknown"),
+        ("Mini Tower", "unknown"),
+        ("Tower", "unknown"),
+        ("Portable", "unknown"),
+        ("Laptop", "unknown"),  # 0x09
+        ("Notebook", "unknown"),  # 0x0A
+        ("Hand Held", "unknown"),
+        ("Docking Station", "unknown"),
+        ("All In One", "LVFS"),  # 0x0D
+        ("Sub Notebook", "unknown"),
+        ("Space-saving", "unknown"),
+        ("Lunch Box", "unknown"),
+        ("Main Server Chassis", "unknown"),  # 0x11
+        ("Expansion Chassis", "unknown"),
+        ("Sub Chassis", "unknown"),
+        ("Bus Expansion Chassis", "unknown"),
+        ("Peripheral Chassis", "unknown"),
+        ("RAID Chassis", "unknown"),
+        ("Rack Mount Chassis", "OEM-defined,LVFS"),  # 0x17
+        ("Sealed-case PC", "unknown"),
+        ("Multi-system", "unknown"),
+        ("CompactPCI", "unknonw"),
+        ("AdvancedTCA", "unknown"),
+        ("Blade", "server"),
+        ("Blade Enclosure", "unknown"),
+        ("Tablet", "unknown"),
+        ("Convertible", "unknown"),  # 0x1F
+        ("Detachable", "unknown"),
+        ("IoT Gateway", "unknown"),  # 0x21
+        ("Embedded PC", "unknown"),
+        ("Mini PC", "LVFS"),  # 0x23
+        ("Stick PC", "unknown"),
+    )
+
+    chassis_names = tuple(c[0] for c in chassis)
+    chassis_types = tuple(c[1] for c in chassis)
+    chassis_name_to_type = dict(chassis)

--- a/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -1,0 +1,93 @@
+"""Base class for flashing firmware on devices"""
+
+import subprocess
+import logging
+from testflinger_device_connectors.fw_devices.dmi import Dmi
+from testflinger_device_connectors.fw_devices import *
+from testflinger_device_connectors import logmsg
+
+
+SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+target_device_username = "ubuntu"
+
+
+def all_subclasses(cls):
+    return cls.__subclasses__() + [
+        g for s in cls.__subclasses__() for g in all_subclasses(s)
+    ]
+
+
+def detect_device(
+    ip: str, user: str, password: str = "", **options
+) -> AbstractDevice:
+    """
+    Detect device's firmware upgrade type by checking on DMI data
+
+    :ip:        DUT IP
+    :user:      DUT user
+    :password:  DUT password (default=blank)
+    :return:    device class object
+    :rtype:     an instance of a class that implements AbstractDevice
+    """
+    temp_device = LVFSDevice(ip, user, password)
+    run_ssh = temp_device.run_cmd
+    devices = all_subclasses(AbstractDevice)
+    try:
+        dmi_chassis_vendor = "sudo cat /sys/class/dmi/id/chassis_vendor"
+        dmi_chassis_type = "sudo cat /sys/class/dmi/id/chassis_type"
+        rc1, vendor_string, stderr1 = run_ssh(
+            dmi_chassis_vendor, raise_stderr=False
+        )
+        rc2, type_string, stderr2 = run_ssh(
+            dmi_chassis_type, raise_stderr=False
+        )
+
+        err_msg = ""
+        if rc1 != 0:
+            err_msg = vendor_string + stderr1 + "\n"
+        if rc2 != 0:
+            err_msg = err_msg + type_string + stderr2
+        if err_msg:
+            err_msg = (
+                "Unable to detect device vendor/type due to lacking of dmi info.\n"
+                + err_msg
+            )
+            logmsg(logging.ERROR, err_msg)
+            raise SystemExit(err_msg)
+
+        type_index = int(type_string)
+        upgrade_type = Dmi.chassis_types[type_index]
+        try:
+            dev = [
+                dev
+                for dev in devices
+                if dev.fw_update_type in upgrade_type
+                and any(x == vendor_string for x in dev.vendor)
+            ][0]
+            logmsg(logging.INFO, f"{ip} is a {vendor_string} {dev.__name__}")
+
+        except IndexError:
+            err_msg = f"{vendor_string} {Dmi.chassis_names[type_index]} Device is not in current support scope"
+            logmsg(logging.ERROR, err_msg)
+            raise SystemExit(err_msg)
+
+        if issubclass(dev, LVFSDevice):
+            return dev(ip, user, password)
+        elif issubclass(dev, OEMDevice):
+            if not (
+                "bmc_ip" in options
+                and "bmc_user" in options
+                and "bmc_password" in options
+            ):
+                raise SystemExit(
+                    "Please provide $BMC_IP, $BMC_USER, $BMC_PASSWORD for this device"
+                )
+            return dev(
+                options.get("bmc_ip"),
+                options.get("bmc_user"),
+                options.get("bmc_password"),
+            )
+    except subprocess.CalledProcessError as e:
+        logmsg(logging.ERROR, e.output)
+        raise RuntimeError(e.output)
+

--- a/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -3,7 +3,12 @@
 import subprocess
 import logging
 from testflinger_device_connectors.fw_devices.dmi import Dmi
-from testflinger_device_connectors.fw_devices import *
+from testflinger_device_connectors.fw_devices import (
+    AbstractDevice,
+    LVFSDevice,
+    OEMDevice,
+)
+from testflinger_device_connectors import logmsg
 
 
 SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
@@ -82,4 +87,3 @@ def detect_device(
     elif issubclass(dev, OEMDevice):
         logmsg(logging.INFO, err_msg)
         raise RuntimeError(err_msg)
-

--- a/src/testflinger_device_connectors/fw_devices/firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/firmware_update.py
@@ -1,14 +1,12 @@
-"""Base class for flashing firmware on devices"""
+"""Detecting device types"""
 
 import subprocess
 import logging
 from testflinger_device_connectors.fw_devices.dmi import Dmi
 from testflinger_device_connectors.fw_devices import *
-from testflinger_device_connectors import logmsg
 
 
 SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-target_device_username = "ubuntu"
 
 
 def all_subclasses(cls):
@@ -23,15 +21,16 @@ def detect_device(
     """
     Detect device's firmware upgrade type by checking on DMI data
 
-    :ip:        DUT IP
-    :user:      DUT user
-    :password:  DUT password (default=blank)
-    :return:    device class object
-    :rtype:     an instance of a class that implements AbstractDevice
+    :param ip:        DUT IP
+    :param user:      DUT user
+    :param password:  DUT password (default=blank)
+    :return:          device class object
+    :rtype:           an instance of a class that implements AbstractDevice
     """
     temp_device = LVFSDevice(ip, user, password)
     run_ssh = temp_device.run_cmd
     devices = all_subclasses(AbstractDevice)
+
     try:
         dmi_chassis_vendor = "sudo cat /sys/class/dmi/id/chassis_vendor"
         dmi_chassis_type = "sudo cat /sys/class/dmi/id/chassis_type"
@@ -41,53 +40,46 @@ def detect_device(
         rc2, type_string, stderr2 = run_ssh(
             dmi_chassis_type, raise_stderr=False
         )
-
-        err_msg = ""
-        if rc1 != 0:
-            err_msg = vendor_string + stderr1 + "\n"
-        if rc2 != 0:
-            err_msg = err_msg + type_string + stderr2
-        if err_msg:
-            err_msg = (
-                "Unable to detect device vendor/type due to lacking of dmi info.\n"
-                + err_msg
-            )
-            logmsg(logging.ERROR, err_msg)
-            raise SystemExit(err_msg)
-
-        type_index = int(type_string)
-        upgrade_type = Dmi.chassis_types[type_index]
-        try:
-            dev = [
-                dev
-                for dev in devices
-                if dev.fw_update_type in upgrade_type
-                and any(x == vendor_string for x in dev.vendor)
-            ][0]
-            logmsg(logging.INFO, f"{ip} is a {vendor_string} {dev.__name__}")
-
-        except IndexError:
-            err_msg = f"{vendor_string} {Dmi.chassis_names[type_index]} Device is not in current support scope"
-            logmsg(logging.ERROR, err_msg)
-            raise SystemExit(err_msg)
-
-        if issubclass(dev, LVFSDevice):
-            return dev(ip, user, password)
-        elif issubclass(dev, OEMDevice):
-            if not (
-                "bmc_ip" in options
-                and "bmc_user" in options
-                and "bmc_password" in options
-            ):
-                raise SystemExit(
-                    "Please provide $BMC_IP, $BMC_USER, $BMC_PASSWORD for this device"
-                )
-            return dev(
-                options.get("bmc_ip"),
-                options.get("bmc_user"),
-                options.get("bmc_password"),
-            )
     except subprocess.CalledProcessError as e:
         logmsg(logging.ERROR, e.output)
         raise RuntimeError(e.output)
+
+    err_msg = ""
+    if rc1 != 0:
+        err_msg = vendor_string + stderr1 + "\n"
+    if rc2 != 0:
+        err_msg = err_msg + type_string + stderr2
+    if err_msg:
+        err_msg = (
+            "Unable to detect device vendor/type due to lacking of dmi info.\n"
+            + err_msg
+        )
+        logmsg(logging.ERROR, err_msg)
+        raise RuntimeError(err_msg)
+
+    type_index = int(type_string)
+    upgrade_type = Dmi.chassis_types[type_index]
+    err_msg = (
+        f"DMI chassis_vendor: {vendor_string} "
+        + f"chassis_type: {Dmi.chassis_names[type_index]} "
+        + "is not in current support scope"
+    )
+
+    try:
+        dev = [
+            dev
+            for dev in devices
+            if dev.fw_update_type in upgrade_type
+            and any(x == vendor_string for x in dev.vendor)
+        ][0]
+        logmsg(logging.INFO, f"{ip} is a {vendor_string} {dev.__name__}")
+    except IndexError:
+        logmsg(logging.ERROR, err_msg)
+        raise RuntimeError(err_msg)
+
+    if issubclass(dev, LVFSDevice):
+        return dev(ip, user, password)
+    elif issubclass(dev, OEMDevice):
+        logmsg(logging.INFO, err_msg)
+        raise RuntimeError(err_msg)
 

--- a/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -5,7 +5,9 @@ import unittest
 import pytest
 from unittest.mock import patch
 from testflinger_device_connectors.fw_devices import *
-from testflinger_device_connectors.fw_devices.firmware_update import detect_device
+from testflinger_device_connectors.fw_devices.firmware_update import (
+    detect_device,
+)
 
 
 vendor_cmd = "sudo cat /sys/class/dmi/id/chassis_vendor"
@@ -70,44 +72,52 @@ class TestFirmwareUpdate(unittest.TestCase):
 
     def test_detect_device_supported(self):
         """Test if detects_device returns a correct device class"""
-        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with patch(
+            "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+        ) as mock_path:
             mock_path.side_effect = self.mock_run_cmd_supported
             device = detect_device("", "", "")
             self.assertTrue(isinstance(device, LVFSDevice))
 
     def test_detect_device_unsupported(self):
         """Test if detects_device exits while given a unsupported device"""
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with pytest.raises(RuntimeError) as pytest_wrapped_e:
+            with patch(
+                "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+            ) as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_unsupported
                 detect_device("", "", "")
-        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertEqual(pytest_wrapped_e.type, RuntimeError)
         self.assertIn(
-            "Device is not in current support scope",
-            pytest_wrapped_e.value.code,
+            "is not in current support scope",
+            str(pytest_wrapped_e.value),
         )
 
     def test_detect_device_fail(self):
         """Test if detects_device exits while given a device without dmi data"""
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with pytest.raises(RuntimeError) as pytest_wrapped_e:
+            with patch(
+                "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+            ) as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_fail
                 detect_device("", "", "")
-        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertEqual(pytest_wrapped_e.type, RuntimeError)
         self.assertIn(
             "Unable to detect device vendor/type due to lacking of dmi info",
-            pytest_wrapped_e.value.code,
+            str(pytest_wrapped_e.value),
         )
 
     def test_detect_device_nossh(self):
         """Test if detects_device exits while given an unreachable device"""
-        with pytest.raises(SystemExit) as pytest_wrapped_e:
-            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+        with pytest.raises(RuntimeError) as pytest_wrapped_e:
+            with patch(
+                "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
+            ) as mock_path:
                 mock_path.side_effect = self.mock_run_cmd_nossh
                 detect_device("", "", "")
-        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertEqual(pytest_wrapped_e.type, RuntimeError)
         self.assertIn(
             "Unable to detect device vendor/type due to lacking of dmi info",
-            pytest_wrapped_e.value.code,
+            str(pytest_wrapped_e.value),
         )
 

--- a/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -1,0 +1,113 @@
+"""Test detect_device in firmware_update.py"""
+
+
+import unittest
+import pytest
+from unittest.mock import patch
+from testflinger_device_connectors.fw_devices import *
+from testflinger_device_connectors.fw_devices.firmware_update import detect_device
+
+
+vendor_cmd = "sudo cat /sys/class/dmi/id/chassis_vendor"
+type_cmd = "sudo cat /sys/class/dmi/id/chassis_type"
+
+
+class TestFirmwareUpdate(unittest.TestCase):
+    def mock_run_cmd_supported(*args, **kwargs):
+        """
+        Mock run_cmd for a HP All In One device, which has a supported
+        Device class.
+        """
+        if args[1] == vendor_cmd:
+            return 0, "HP", ""
+        elif args[1] == type_cmd:
+            return 0, "13", ""
+
+    def mock_run_cmd_unsupported(*args, **kwargs):
+        """
+        Mock run_cmd for an Intel Desktop device (201808-26453), which doesn't
+        have a supported Device class.
+        """
+        if args[1] == vendor_cmd:
+            return 0, "Default string", ""
+        elif args[1] == type_cmd:
+            return 0, "3", ""
+
+    def mock_run_cmd_fail(*args, **kwargs):
+        """
+        Mock run_cmd for a Rigado Cascade 500 device (201810-26506), which doesn't
+        provide dmi data.
+        """
+        if args[1] == vendor_cmd:
+            return (
+                1,
+                "cat: /sys/class/dmi/id/chassis_vendor: No such file or directory",
+                "",
+            )
+        elif args[1] == type_cmd:
+            return (
+                1,
+                "cat: /sys/class/dmi/id/chassis_type: No such file or directory",
+                "",
+            )
+
+    def mock_run_cmd_nossh(*args, **kwargs):
+        """
+        Mock run_cmd to simulate an unreachable device.
+        """
+        if args[1] == vendor_cmd:
+            return (
+                255,
+                "",
+                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+            )
+        elif args[1] == type_cmd:
+            return (
+                255,
+                "",
+                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+            )
+
+    def test_detect_device_supported(self):
+        """Test if detects_device returns a correct device class"""
+        with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+            mock_path.side_effect = self.mock_run_cmd_supported
+            device = detect_device("", "", "")
+            self.assertTrue(isinstance(device, LVFSDevice))
+
+    def test_detect_device_unsupported(self):
+        """Test if detects_device exits while given a unsupported device"""
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+                mock_path.side_effect = self.mock_run_cmd_unsupported
+                detect_device("", "", "")
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Device is not in current support scope",
+            pytest_wrapped_e.value.code,
+        )
+
+    def test_detect_device_fail(self):
+        """Test if detects_device exits while given a device without dmi data"""
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+                mock_path.side_effect = self.mock_run_cmd_fail
+                detect_device("", "", "")
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Unable to detect device vendor/type due to lacking of dmi info",
+            pytest_wrapped_e.value.code,
+        )
+
+    def test_detect_device_nossh(self):
+        """Test if detects_device exits while given an unreachable device"""
+        with pytest.raises(SystemExit) as pytest_wrapped_e:
+            with patch("testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd") as mock_path:
+                mock_path.side_effect = self.mock_run_cmd_nossh
+                detect_device("", "", "")
+        self.assertEqual(pytest_wrapped_e.type, SystemExit)
+        self.assertIn(
+            "Unable to detect device vendor/type due to lacking of dmi info",
+            pytest_wrapped_e.value.code,
+        )
+

--- a/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
+++ b/src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py
@@ -4,7 +4,7 @@
 import unittest
 import pytest
 from unittest.mock import patch
-from testflinger_device_connectors.fw_devices import *
+from testflinger_device_connectors.fw_devices import LVFSDevice
 from testflinger_device_connectors.fw_devices.firmware_update import (
     detect_device,
 )
@@ -27,8 +27,8 @@ class TestFirmwareUpdate(unittest.TestCase):
 
     def mock_run_cmd_unsupported(*args, **kwargs):
         """
-        Mock run_cmd for an Intel Desktop device (201808-26453), which doesn't
-        have a supported Device class.
+        Mock run_cmd for an Intel Desktop device (201808-26453), which
+        doesn't have a supported Device class.
         """
         if args[1] == vendor_cmd:
             return 0, "Default string", ""
@@ -37,19 +37,21 @@ class TestFirmwareUpdate(unittest.TestCase):
 
     def mock_run_cmd_fail(*args, **kwargs):
         """
-        Mock run_cmd for a Rigado Cascade 500 device (201810-26506), which doesn't
-        provide dmi data.
+        Mock run_cmd for a Rigado Cascade 500 device (201810-26506), which
+        doesn't provide dmi data.
         """
         if args[1] == vendor_cmd:
             return (
                 1,
-                "cat: /sys/class/dmi/id/chassis_vendor: No such file or directory",
+                "cat: /sys/class/dmi/id/chassis_vendor: "
+                "No such file or directory",
                 "",
             )
         elif args[1] == type_cmd:
             return (
                 1,
-                "cat: /sys/class/dmi/id/chassis_type: No such file or directory",
+                "cat: /sys/class/dmi/id/chassis_type: "
+                "No such file or directory",
                 "",
             )
 
@@ -61,13 +63,15 @@ class TestFirmwareUpdate(unittest.TestCase):
             return (
                 255,
                 "",
-                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+                "ssh: connect to host 10.102.161.93 port 22: "
+                "No route to host",
             )
         elif args[1] == type_cmd:
             return (
                 255,
                 "",
-                "ssh: connect to host 10.102.161.93 port 22: No route to host",
+                "ssh: connect to host 10.102.161.93 port 22: "
+                "No route to host",
             )
 
     def test_detect_device_supported(self):
@@ -94,7 +98,9 @@ class TestFirmwareUpdate(unittest.TestCase):
         )
 
     def test_detect_device_fail(self):
-        """Test if detects_device exits while given a device without dmi data"""
+        """
+        Test if detects_device exits while given a device without dmi data
+        """
         with pytest.raises(RuntimeError) as pytest_wrapped_e:
             with patch(
                 "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
@@ -108,7 +114,9 @@ class TestFirmwareUpdate(unittest.TestCase):
         )
 
     def test_detect_device_nossh(self):
-        """Test if detects_device exits while given an unreachable device"""
+        """
+        Test if detects_device exits while given an unreachable device
+        """
         with pytest.raises(RuntimeError) as pytest_wrapped_e:
             with patch(
                 "testflinger_device_connectors.fw_devices.LVFSDevice.run_cmd"
@@ -120,4 +128,3 @@ class TestFirmwareUpdate(unittest.TestCase):
             "Unable to detect device vendor/type due to lacking of dmi info",
             str(pytest_wrapped_e.value),
         )
-


### PR DESCRIPTION
## Description
Base on [CR033 - Firmware updates for regression testing](https://docs.google.com/document/d/1yMYK5IUFyhb8Y5-pbxOjBekvRkasbUjee7Nw1ySkA5g), introduce a new optional phase **firmware_update** after provision phase to handle request for firmware update on the device. As in the spec, this new phase is implemented in `DefaultDevice`, so it won't need any change on existing `DeviceConnector` codes.

To trigger **firmware_update** phase, the following section needs to be provided in job.yaml. If the `firmware_update_data` section is missing from the job, this phase will not run. 
```
firmware_update_data:
  version: < latest >
  ignore_failure: < false | true >
```
Variables in `firmware_update_data`:
- `version`: The desired firmware level on the device. Currently it only supports `latest` (upgrading all components in the device with the latest firmware release). More options are planned to be implemented in the future once we gathering data for working firmware baseline on devices.
- `ignore_failure`: When set to `false`, **Testflinger Agent** will suspend the job if **firmware_update** phase return a status other than 0, which implies there's a failure during firmware_update phase. If set to `true`, the job will continue regardless the status of **firmware_update** phase.

### Code changes
Add `firmware_update` phase in `DefaultDevice` to handle the firmware update for all child `DeviceConnector` class. It will gather DMI chassis_vendor and chassis_type from the DUT to decide whether firmware update is applicable. The current support scope is limited the devices as below.
```
chassis_vendor: HP, Lenovo, Dell
chassis_type: All In One, Desktop, Mini PC, Rack Mount Chassis
```

In order to make it work as a whole, there're also PRs raised in [testflinger](https://github.com/canonical/testflinger/pull/114) and [testflinger-agent](https://github.com/canonical/testflinger-agent/pull/40).


## Resolved issues

<!--
Note the Jira and GitHub issue(s) resolved by this PR (`Fixes|Resolves ...`).
Make sure that the linked issue titles & descriptions are also up to date.
-->
 N/A
## Documentation
Covered in testflinger monorepo.


## Tests

It's tested by building a [dev testflinger server](https://github.com/canonical/testflinger/pull/114) with [docker](https://github.com/canonical/testflinger/blob/main/HACKING.md#docker) along with modified testflinger-agent and snappy-device-agents.

- [x] Unit tests
```
(env) ubuntu@juju-ee0bf9-0:/srv/testflinger-agent/dell-optiplex3070-c26629/snappy-device-agents$  sudo  /srv/testflinger-agent/dell-optiplex3070-c26629/env/bin/python3 -m coverage run -m pytest .
============================================== test session starts ==============================================
platform linux -- Python 3.8.10, pytest-7.4.2, pluggy-1.3.0
rootdir: /srv/testflinger-agent/dell-optiplex3070-c26629/snappy-device-agents
plugins: requests-mock-1.11.0
collecting ... 
collected 36 items                                                                                              

src/testflinger_device_connectors/devices/maas2/tests/test_maas_storage.py ..................             [ 50%]
src/testflinger_device_connectors/devices/multi/tests/test_multi.py ....                                  [ 61%]
src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py E                                     [ 63%]
src/testflinger_device_connectors/fw_devices/LVFS/tests/test_LVFS.py ......                               [ 80%]
src/testflinger_device_connectors/fw_devices/tests/test_firmware_update.py ....                           [ 91%]
src/tests/test_snappy_device_agents.py ...                                                                [100%]

==================================================== ERRORS =====================================================
_________________________________ ERROR at setup of test_check_ce_oem_iot_image _________________________________
file /srv/testflinger-agent/dell-optiplex3070-c26629/snappy-device-agents/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py, line 20
  def test_check_ce_oem_iot_image(mocker):
E       fixture 'mocker' not found
>       available fixtures: cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, monkeypatch, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, requests_mock, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/srv/testflinger-agent/dell-optiplex3070-c26629/snappy-device-agents/src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py:20
=============================================== warnings summary ================================================
../env/lib/python3.8/site-packages/testflinger_device_connectors/devices/__init__.py:15
  /srv/testflinger-agent/dell-optiplex3070-c26629/env/lib/python3.8/site-packages/testflinger_device_connectors/devices/__init__.py:15: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================ short test summary info ============================================
ERROR src/testflinger_device_connectors/devices/muxpi/tests/test_muxpi.py::test_check_ce_oem_iot_image
==================================== 35 passed, 1 warning, 1 error in 0.25s =====================================
````
- [x] Testflinger Agent is able to work with Testflinger Device Connector (tested with noprovision) to run **firmware_update** phase
```
**************************************************************************

* Starting testflinger firmware_update phase on dell-optiplex3070-c26629 *

**************************************************************************
2023-10-13 12:06:46,578 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: BEGIN firmware_update
2023-10-13 12:06:47,130 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: 10.102.163.206 is a Dell Inc. LVFSDevice
2023-10-13 12:06:57,154 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: collect firmware info
2023-10-13 12:06:58,600 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: [ST500LM021-1KJ152] current version: 0005SDM1 - no available firmware on LVFS
2023-10-13 12:06:58,601 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: [System Firmware] current version: 1.21.0 - LVFS upgradable version(s): 1.22.0 - LVFS downgradable version(s): 1.20.0
2023-10-13 12:06:58,601 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: [UEFI dbx] current version: 77 - no available firmware on LVFS
2023-10-13 12:06:58,601 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: start upgrading
2023-10-13 12:06:58,601 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: [System Firmware] try upgrading to 1.22.0
2023-10-13 12:07:05,600 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: reboot DUT
2023-10-13 12:07:16,680 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: check and wait for 900s until 10.102.163.206 is SSHable
2023-10-13 12:08:53,927 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: 10.102.163.206 is SSHable after 97s
2023-10-13 12:09:01,255 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: [System Firmware] FWUPD_UPDATE_STATE_FAILED: failed to run update on reboot
2023-10-13 12:09:01,255 dell-optiplex3070-c26629 INFO: DEVICE CONNECTOR: END firmware_update
```