### PR TITLE
Add state check to check_device_booted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ requires-python = ">=3.8"
 dependencies = [
     "PyYAML>=3.11",
     "requests",
+    "wrapt_timeout_decorator",
+    "paramiko",
 ]
 
 [project.scripts]


### PR DESCRIPTION
impact:
    snappy-device-agents/src/testflinger_device_connectors/devices/oemrecovery/oemrecovery.py

description:
    currently check_device_booted not really check device current state
    and we found it could end up login into install mode state or run mode but before device ready.
    For making sure everything is ready before we start testing procedure, we add state checking.

test:
    using oemrecovery with command snap reboot --install on x8high-pdk pass